### PR TITLE
Fix corner cases for side nav when finding selected id

### DIFF
--- a/public/components/common/side_nav.tsx
+++ b/public/components/common/side_nav.tsx
@@ -13,16 +13,24 @@ import { EuiPage, EuiPageBody, EuiPageSideBar, EuiSideNav, EuiSideNavItemType } 
 import React from 'react';
 
 export const renderPageWithSidebar = (BodyComponent: React.ReactNode) => {
-  function setIsSelected(items: EuiSideNavItemType<React.ReactNode>[], hash: string) {
+  // set items.isSelected based on location.hash passed in
+  // tries to find an item where href is a prefix of the hash
+  // if none will try to find an item where the hash is a prefix of href
+  function setIsSelected(
+    items: EuiSideNavItemType<React.ReactNode>[],
+    hash: string,
+    initial = true,
+    reverse = false
+  ): boolean {
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
-      if (item.href === hash) {
+      if (item.href && ((reverse && item.href.startsWith(hash)) || hash.startsWith(item.href))) {
         item.isSelected = true;
         return true;
       }
-      if (item.items?.length && setIsSelected(item.items, hash)) return true;
+      if (item.items?.length && setIsSelected(item.items, hash, false, reverse)) return true;
     }
-    return false;
+    return initial && setIsSelected(items, hash, false, !reverse);
   }
 
   const items = [


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Fix some corner cases where side nav won't be able to identify which item is selected (e.g. when url hash has additional `search` params, or missing last `/`, `/home` etc).
Trying to avoid the need to manually specifying the selected index, feel free to comment if there's a better way

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
