### PR TITLE
Update notebooks to use observability backend

### DIFF
--- a/public/components/notebooks/components/helpers/reporting_context_menu_helper.tsx
+++ b/public/components/notebooks/components/helpers/reporting_context_menu_helper.tsx
@@ -140,7 +140,10 @@ export const generateInContextReport = async (
   rest = {}
 ) => {
   toggleReportingLoadingModal(true);
-  let baseUrl = location.pathname + location.hash + '?view=output_only';  
+  let baseUrl =
+    location.pathname +
+    location.hash.replace(/\?view=(view_both|input_only|output_only)/, '') +
+    '?view=output_only';
   // Add selected tenant info to url
   try {
     const tenant = await getTenantInfoIfExists();

--- a/server/routes/notebooks/noteRouter.ts
+++ b/server/routes/notebooks/noteRouter.ts
@@ -128,7 +128,7 @@ export function registerNoteRoute(router: IRouter) {
           wreckOptions
         );
         return response.ok({
-          body: addResponse.message.notebookId,
+          body: addResponse.message.objectId,
         });
       } catch (error) {
         return response.custom({


### PR DESCRIPTION
### Description
- update dashboards server notebooks endpoints and request/response schema to observability
- update url for reporting to include `view` param (previously notebooks used JS api to set `view`, currently it uses react router API)

Reporting integration relies on https://github.com/opensearch-project/dashboards-reports/pull/174

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
