### PR TITLE
Autocomplete only displays current command

### DIFF
--- a/dashboards-observability/public/components/common/search/autocomplete_plugin.ts
+++ b/dashboards-observability/public/components/common/search/autocomplete_plugin.ts
@@ -10,7 +10,6 @@
  */
 
 import { AutocompletePlugin } from '@algolia/autocomplete-js';
-import { CUSTOM_PANELS_API_PREFIX } from 'common/constants/custom_panels';
 import DSLService from 'public/services/requests/dsl';
 import { getDataValueQuery } from './queries/data_queries';
 


### PR DESCRIPTION
### Description
Search bar in event analytics now only displays suggestions and nothing before it.

### Issues Resolved
When customers had multiple commands in their search query, the suggestion displayed would include all commands. This was redundant and wordy. 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
