### PR TITLE
changed to support query without 'search' prefix

### DIFF
--- a/dashboards-observability/common/constants/shared.ts
+++ b/dashboards-observability/common/constants/shared.ts
@@ -35,7 +35,7 @@ export const observabilityPluginOrder = 6000;
 export const UI_DATE_FORMAT = 'MM/DD/YYYY hh:mm A';
 export const PPL_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 export const PPL_STATS_REGEX = /\|\s*stats/i;
-export const PPL_INDEX_INSERT_POINT_REGEX = /search (source|index)\s*=\s*([^\s]+)(.*)/i;
+export const PPL_INDEX_INSERT_POINT_REGEX = /(search source|source|index)\s*=\s*([^\s]+)(.*)/i;
 export const PPL_INDEX_REGEX = /(search source|source|index)\s*=\s*([^|\s]+)/i;
 
 // Observability plugin URI

--- a/dashboards-observability/common/types/explorer.ts
+++ b/dashboards-observability/common/types/explorer.ts
@@ -20,7 +20,11 @@ import {
   SELECTED_TIMESTAMP,
   SELECTED_DATE_RANGE
  } from '../constants/explorer';
+ import { HttpStart } from '../../../../src/core/public';
  import SavedObjects from '../../public/services/saved_objects/event_analytics/saved_objects';
+ import TimestampUtils from '../../public/services/timestamp/timestamp';
+ import PPLService from '../../public/services/requests/ppl';
+ import DSLService from '../../public/services/requests/dsl';
 
 export interface IQueryTab {
   id: string;
@@ -61,7 +65,15 @@ export interface IExplorerFields {
 }
 
 export interface ILogExplorerProps {
-  pplService: any;
-  dslService: any;
+  pplService: PPLService;
+  dslService: DSLService;
   savedObjects: SavedObjects;
+  http: HttpStart;
+  timestampUtils: TimestampUtils;
+  setToast: (
+    title: string,
+    color?: string,
+    text?: React.ReactChild | undefined,
+    side?: string | undefined
+  ) => void;
 }

--- a/dashboards-observability/common/utils/query_utils.ts
+++ b/dashboards-observability/common/utils/query_utils.ts
@@ -47,7 +47,7 @@ export const insertDateRangeToQuery = ({
   const tokens = rawQuery.match(PPL_INDEX_INSERT_POINT_REGEX);
   
   if (isEmpty(tokens)) return finalQuery;
-  finalQuery = `search ${tokens![1]}=${tokens![2]} | where ${timeField} >= timestamp('${start}') and ${timeField} <= timestamp('${end}')${tokens![3]}`;
+  finalQuery = `${tokens![1]}=${tokens![2]} | where ${timeField} >= timestamp('${start}') and ${timeField} <= timestamp('${end}')${tokens![3]}`;
 
   return finalQuery;
 };


### PR DESCRIPTION
Signed-off-by: Eric Wei <menwe@amazon.com>

### Description
Previously it is unable to get hits without a search in front of a query, now this issue was fixed in this PR.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ x ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
