### PR TITLE
Improve reindex handling for .opensearch-notebooks

### DIFF
--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/index/ObservabilityIndex.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/index/ObservabilityIndex.kt
@@ -31,7 +31,6 @@ import org.opensearch.ResourceAlreadyExistsException
 import org.opensearch.ResourceNotFoundException
 import org.opensearch.action.DocWriteResponse
 import org.opensearch.action.admin.indices.create.CreateIndexRequest
-import org.opensearch.action.admin.indices.delete.DeleteIndexRequest
 import org.opensearch.action.bulk.BulkRequest
 import org.opensearch.action.delete.DeleteRequest
 import org.opensearch.action.get.GetRequest
@@ -134,6 +133,7 @@ internal object ObservabilityIndex {
     /**
      * Reindex .opensearch-notebooks to .opensearch-observability index
      */
+    @Suppress("TooGenericExceptionCaught")
     private fun reindexNotebooks() {
         if (isIndexExists(NOTEBOOKS_INDEX_NAME)) {
             try {
@@ -151,9 +151,15 @@ internal object ObservabilityIndex {
                 } else if (reindexResponse.bulkFailures.isNotEmpty()) {
                     throw IllegalStateException("$LOG_PREFIX:Index - reindex $NOTEBOOKS_INDEX_NAME failed with bulkFailures")
                 } else if (reindexResponse.total != reindexResponse.created + reindexResponse.updated) {
-                    throw IllegalStateException("$LOG_PREFIX:Index - reindex number of docs created:${reindexResponse.created} + updated:${reindexResponse.updated} does not equal requested:${reindexResponse.total}")
+                    throw IllegalStateException(
+                        "$LOG_PREFIX:Index - reindex number of docs created:${reindexResponse.created} + " +
+                            "updated:${reindexResponse.updated} does not equal requested:${reindexResponse.total}"
+                    )
                 }
-                log.info("$LOG_PREFIX:Index - reindex ${reindexResponse.created} docs created and ${reindexResponse.updated} docs updated in $INDEX_NAME")
+                log.info(
+                    "$LOG_PREFIX:Index - reindex ${reindexResponse.created} docs created " +
+                        "and ${reindexResponse.updated} docs updated in $INDEX_NAME"
+                )
             } catch (exception: Exception) {
                 if (exception !is ResourceNotFoundException && exception.cause !is ResourceNotFoundException) {
                     throw exception


### PR DESCRIPTION
### Description
- remove logic to delete the .opensearch-notebooks index
- only reindex after create .opensearch-observability index succeeded to ensure it'll only run once
- add doc count check and fail if count does not match

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
