### PR TITLE
Inherited datepicker format from settings

### DIFF
--- a/dashboards-observability/common/utils/index.ts
+++ b/dashboards-observability/common/utils/index.ts
@@ -10,3 +10,4 @@
  */
 
 export { getIndexPatternFromRawQuery, insertDateRangeToQuery } from './query_utils';
+export { uiSettingsService } from './settings_service';

--- a/dashboards-observability/common/utils/settings_service.ts
+++ b/dashboards-observability/common/utils/settings_service.ts
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { IUiSettingsClient } from '../../../../src/core/public';
+
+let uiSettings: IUiSettingsClient;
+
+export const uiSettingsService = {
+  init: (client: IUiSettingsClient) => {
+    uiSettings = client;
+  },
+  get: (key: string, defaultOverride?: any) => {
+    return uiSettings?.get(key, defaultOverride) || '';
+  },
+};

--- a/dashboards-observability/public/components/common/search/date_picker.tsx
+++ b/dashboards-observability/public/components/common/search/date_picker.tsx
@@ -17,6 +17,7 @@ import {
 import {
   IDatePickerProps
 } from './search';
+import { uiSettingsService } from '../../../../common/utils';
 
 export function DatePicker(props: IDatePickerProps) {
 
@@ -66,7 +67,7 @@ export function DatePicker(props: IDatePickerProps) {
         start={ startTime }
         end={ endTime }
         showUpdateButton={ false }
-        dateFormat="MM/DD/YYYY hh:mm:ss A"
+        dateFormat={uiSettingsService.get('dateFormat')}
         onTimeChange={(e) => {
           const start = e.start;
           const end = e.start === e.end ? 'now' : e.end;

--- a/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
+++ b/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
@@ -48,6 +48,7 @@ import { UI_DATE_FORMAT } from '../../../common/constants/shared';
 import { ChangeEvent } from 'react';
 import moment from 'moment';
 import { VisaulizationFlyout } from './panel_modules/visualization_flyout';
+import { uiSettingsService } from '../../../common/utils';
 
 /*
  * "CustomPanelsView" module used to render an Operational Panel
@@ -537,7 +538,7 @@ export const CustomPanelView = ({
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiSuperDatePicker
-                  dateFormat={UI_DATE_FORMAT}
+                  dateFormat={uiSettingsService.get('dateFormat')}
                   start={start}
                   end={end}
                   onTimeChange={onDatePickerChange}

--- a/dashboards-observability/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
@@ -205,7 +205,7 @@ export const VisaulizationFlyout = ({
             endDate={endDate}
             isInvalid={startDate > endDate}
             aria-label="Start date"
-            dateFormat={UI_DATE_FORMAT}
+            dateFormat={uiSettingsService.get('dateFormat')}
           />
         }
         endDateControl={
@@ -215,7 +215,7 @@ export const VisaulizationFlyout = ({
             endDate={endDate}
             isInvalid={startDate > endDate}
             aria-label="End date"
-            dateFormat={UI_DATE_FORMAT}
+            dateFormat={uiSettingsService.get('dateFormat')}
           />
         }
       />

--- a/dashboards-observability/public/components/notebooks/components/paragraph_components/para_input.tsx
+++ b/dashboards-observability/public/components/notebooks/components/paragraph_components/para_input.tsx
@@ -47,6 +47,7 @@ import {
   EuiTextArea,
 } from '@elastic/eui';
 import { Input, Prompt, Source } from '@nteract/presentational-components';
+import { uiSettingsService } from '../../../../../common/utils';
 import React, { useState } from 'react';
 import { ParaType } from '../../../../../common/types/notebooks';
 
@@ -169,7 +170,7 @@ export const ParaInput = (props: {
                 start={props.startTime}
                 end={props.endTime}
                 showUpdateButton={false}
-                dateFormat="MM/DD/YYYY hh:mm:ss A"
+                dateFormat={uiSettingsService.get('dateFormat')}
                 onTimeChange={(e) => {
                   props.setStartTime(e.start);
                   props.setEndTime(e.end);

--- a/dashboards-observability/public/components/trace_analytics/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
+++ b/dashboards-observability/public/components/trace_analytics/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`Search bar components renders date picker 1`] = `
       },
     ]
   }
-  dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+  dateFormat=""
   end="now"
   isAutoRefreshOnly={false}
   isDisabled={false}
@@ -120,7 +120,7 @@ exports[`Search bar components renders date picker 1`] = `
                     },
                   ]
                 }
-                dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                dateFormat=""
                 end="now"
                 isAutoRefreshOnly={false}
                 isDisabled={false}
@@ -181,7 +181,7 @@ exports[`Search bar components renders date picker 1`] = `
                     },
                   ]
                 }
-                dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                dateFormat=""
                 end="now"
                 isAutoRefreshOnly={false}
                 isDisabled={false}
@@ -537,7 +537,7 @@ exports[`Search bar components renders search bar 1`] = `
                 },
               ]
             }
-            dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+            dateFormat=""
             end="now"
             isAutoRefreshOnly={false}
             isDisabled={false}
@@ -611,7 +611,7 @@ exports[`Search bar components renders search bar 1`] = `
                               },
                             ]
                           }
-                          dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                          dateFormat=""
                           end="now"
                           isAutoRefreshOnly={false}
                           isDisabled={false}
@@ -672,7 +672,7 @@ exports[`Search bar components renders search bar 1`] = `
                               },
                             ]
                           }
-                          dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                          dateFormat=""
                           end="now"
                           isAutoRefreshOnly={false}
                           isDisabled={false}

--- a/dashboards-observability/public/components/trace_analytics/components/common/search_bar.tsx
+++ b/dashboards-observability/public/components/trace_analytics/components/common/search_bar.tsx
@@ -32,6 +32,7 @@ import {
   EuiSpacer,
   EuiSuperDatePicker,
 } from '@elastic/eui';
+import { uiSettingsService } from '../../../../../common/utils';
 import _ from 'lodash';
 import React, { useState } from 'react';
 import { Filters, FiltersProps } from './filters/filters';
@@ -46,6 +47,7 @@ export const renderDatePicker = (
     <EuiSuperDatePicker
       start={startTime}
       end={endTime}
+      dateFormat={uiSettingsService.get('dateFormat')}
       showUpdateButton={false}
       onTimeChange={(e) => {
         setStartTime(e.start);

--- a/dashboards-observability/public/plugin.ts
+++ b/dashboards-observability/public/plugin.ts
@@ -21,48 +21,50 @@ import TimestampUtils from './services/timestamp/timestamp';
 import SavedObjects from './services/saved_objects/event_analytics/saved_objects';
 import { AppPluginStartDependencies, ObservabilitySetup, ObservabilityStart } from './types';
 import { convertLegacyNotebooksUrl } from './components/notebooks/components/helpers/legacy_route_helpers';
+import { uiSettingsService } from '../common/utils';
 
 export class ObservabilityPlugin implements Plugin<ObservabilitySetup, ObservabilityStart> {
+  public setup(core: CoreSetup): ObservabilitySetup {
+    uiSettingsService.init(core.uiSettings);
 
-    public setup(core: CoreSetup): ObservabilitySetup {
-      // redirect legacy notebooks URL to current URL under observability
-      if (window.location.pathname.includes('notebooks-dashboards')) {
-        window.location.assign(convertLegacyNotebooksUrl(window.location));
-      }
-      
-      core.application.register({
-        id: observabilityID,
-        title: observabilityTitle,
-        category: {
-          id: 'opensearch',
-          label: 'OpenSearch Plugins',
-          order: 2000,
-        },
-        order: observabilityPluginOrder,
-        async mount(params: AppMountParameters) {
-          const { Observability } = await import('./components/index');
-          const [ coreStart, depsStart ] = await core.getStartServices();
-          const pplService = new PPLService(coreStart.http);
-          const dslService = new DSLService(coreStart.http);
-          const savedObjects = new SavedObjects(coreStart.http);
-          const timestampUtils = new TimestampUtils(dslService);
-          return Observability(
-            coreStart,
-            depsStart as AppPluginStartDependencies,
-            params,
-            pplService,
-            dslService,
-            savedObjects,
-            timestampUtils
-          );
-        },
-      });
+    // redirect legacy notebooks URL to current URL under observability
+    if (window.location.pathname.includes('notebooks-dashboards')) {
+      window.location.assign(convertLegacyNotebooksUrl(window.location));
+    }
 
-      // Return methods that should be available to other plugins
-      return {};
-    }
-    public start(core: CoreStart): ObservabilityStart {
-      return {};
-    }
-    public stop() {}
+    core.application.register({
+      id: observabilityID,
+      title: observabilityTitle,
+      category: {
+        id: 'opensearch',
+        label: 'OpenSearch Plugins',
+        order: 2000,
+      },
+      order: observabilityPluginOrder,
+      async mount(params: AppMountParameters) {
+        const { Observability } = await import('./components/index');
+        const [coreStart, depsStart] = await core.getStartServices();
+        const pplService = new PPLService(coreStart.http);
+        const dslService = new DSLService(coreStart.http);
+        const savedObjects = new SavedObjects(coreStart.http);
+        const timestampUtils = new TimestampUtils(dslService);
+        return Observability(
+          coreStart,
+          depsStart as AppPluginStartDependencies,
+          params,
+          pplService,
+          dslService,
+          savedObjects,
+          timestampUtils
+        );
+      },
+    });
+
+    // Return methods that should be available to other plugins
+    return {};
+  }
+  public start(core: CoreStart): ObservabilityStart {
+    return {};
+  }
+  public stop() {}
 }


### PR DESCRIPTION
### Description
The modules in Observability do not support datepicker format provided from advanced settings in Dashboards.

### Issues Resolved
1. Added the settings datepicker format in Panels, Notebooks, Explorer and Trace-Analytics.
2. Updated Trace-Analytics test snapshots. 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
