### PR TITLE
Field suggestions update to match changed index in query

### DIFF
--- a/dashboards-observability/public/components/common/search/autocomplete.tsx
+++ b/dashboards-observability/public/components/common/search/autocomplete.tsx
@@ -22,8 +22,8 @@ import { EuiTextArea } from '@elastic/eui';
 import { IQueryBarProps } from './search';
 import { getDataValueQuery } from './queries/data_queries';
 import { isEmpty, isEqual } from 'lodash';
+import DSLService from 'public/services/requests/dsl';
 
-let queryLength: number = 0;
 let currIndex: string = '';
 let currField: string = '';
 let currFieldType: string = '';
@@ -210,8 +210,9 @@ const getIndices = async (dslService: DSLService) => {
 };
 
 const getFields = async (dslService: DSLService) => {
-  if (fieldsFromBackend.length === 0 && currIndex !== '') {
+  if (currIndex !== '') {
     const res = await dslService.fetchFields(currIndex);
+    fieldsFromBackend.length = 0;
     for (const element in res?.[currIndex].mappings.properties) {
       if (res?.[currIndex].mappings.properties[element].type === 'keyword') {
         fieldsFromBackend.push({ label: element, type: 'string' });


### PR DESCRIPTION
Signed-off by: Eugene Lee <eugenesk@amazon.com>

### Description
Fields are updated when the index in the search query changes. Removed if condition that only got fields if the fieldsFromBackend array was empty. 

### Issues Resolved
If an index was typed in the search query and then changed, the fields suggestions would still display the fields of the first index typed. 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
