### PR TITLE
Use observability specific permissions instead of notebooks

### DIFF
--- a/opensearch-observability/src/main/config/observability.yml
+++ b/opensearch-observability/src/main/config/observability.yml
@@ -37,14 +37,14 @@ opensearch.notebooks:
     maxPollingDurationSeconds: 900 # 15 Minutes, Minimum 5 Minutes
     maxLockRetries: 1 # Max number of retries to retry locking
   access:
-    adminAccess: "AllNotebooks"
+    adminAccess: "AllObservabilityObjects"
     # adminAccess values:
     ## Standard -> Admin user access follows standard user
-    ## AllNotebooks -> Admin user with "all_access" role can see all observability objects of all users.
+    ## AllObservabilityObjects -> Admin user with "all_access" role can see all observability objects of all users.
     filterBy: "NoFilter" # Applied when tenant != __user__
     # filterBy values:
     ## NoFilter -> everyone see each other's observability objects
     ## User -> observability objects are visible to only themselves
     ## Roles -> observability objects are visible to users having any one of the role of creator
     ## BackendRoles -> observability objects are visible to users having any one of the backend role of creator
-    ignoreRoles: ["own_index", "kibana_user", "notebooks_full_access", "notebooks_read_access"]
+    ignoreRoles: ["own_index", "kibana_user", "observability_full_access", "observability_read_access"]

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/security/UserAccessManager.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/security/UserAccessManager.kt
@@ -194,7 +194,7 @@ internal object UserAccessManager {
     }
 
     private fun canAdminViewAllItems(user: User): Boolean {
-        return PluginSettings.adminAccess == PluginSettings.AdminAccess.AllNotebooks && isAdminUser(user)
+        return PluginSettings.adminAccess == PluginSettings.AdminAccess.AllObservabilityObjects && isAdminUser(user)
     }
 
     private fun isAdminUser(user: User): Boolean {

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/settings/PluginSettings.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/settings/PluginSettings.kt
@@ -172,7 +172,7 @@ internal object PluginSettings {
     /**
      * Default admin access method.
      */
-    private const val DEFAULT_ADMIN_ACCESS_METHOD = "AllNotebooks"
+    private const val DEFAULT_ADMIN_ACCESS_METHOD = "AllObservabilityObjects"
 
     /**
      * Default filter-by method.
@@ -246,9 +246,9 @@ internal object PluginSettings {
     /**
      * Enum for types of admin access
      * "Standard" -> Admin user access follows standard user
-     * "AllNotebooks" -> Admin user with "all_access" role can see all notebooks of all users.
+     * "AllObservabilityObjects" -> Admin user with "all_access" role can see all observability objects of all users.
      */
-    internal enum class AdminAccess { Standard, AllNotebooks }
+    internal enum class AdminAccess { Standard, AllObservabilityObjects }
 
     /**
      * Enum for types of filterBy options


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Observability will no longer share roles/permissions with legacy notebooks plugin.

### Issues Resolved
- partially https://github.com/opensearch-project/trace-analytics/issues/178

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
