### PR TITLE
Added refresh datepicker button

### DIFF
--- a/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
+++ b/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
@@ -549,15 +549,9 @@ export const CustomPanelView = ({
                   start={start}
                   end={end}
                   onTimeChange={onDatePickerChange}
-                  showUpdateButton={false}
                   recentlyUsedRanges={recentlyUsedRanges}
                   isDisabled={dateDisabled}
                 />
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButton isDisabled={inputDisabled} onClick={onRefreshFilters}>
-                  Refresh
-                </EuiButton>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiPopover


### PR DESCRIPTION
### Description
Previously panels was using its own refresh button, this led continuous refresh when changing dates. 

### Issues Resolved
Removed the refresh button and added the one provided by super date picker.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
