### PR TITLE
Icon that redirects to PPL Documentation next to Search Bar

### DIFF
--- a/dashboards-observability/public/components/common/search/search.tsx
+++ b/dashboards-observability/public/components/common/search/search.tsx
@@ -21,7 +21,8 @@ import {
   EuiPopover,
   EuiButtonEmpty,
   EuiPopoverFooter,
-  EuiIcon
+  EuiIcon,
+  EuiButtonIcon
 } from '@elastic/eui';
 import _ from 'lodash';
 import { DatePicker } from './date_picker';
@@ -98,7 +99,7 @@ export const Search = (props: any) => {
 
   return (
     <div className="globalQueryBar">
-      <EuiFlexGroup gutterSize="s" justifyContent="flexStart">
+      <EuiFlexGroup gutterSize="s" justifyContent="flexStart" alignItems='center'>
         <EuiFlexItem
           key="search-bar"
         >
@@ -109,6 +110,9 @@ export const Search = (props: any) => {
             handleQuerySearch={memorizedHandleQuerySearch}
             dslService={dslService}
           />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+        <EuiButtonIcon iconType='documents' href='https://opensearch.org/docs/latest/search-plugins/ppl/commands/'/>
         </EuiFlexItem>
         <EuiFlexItem
           className="euiFlexItem--flexGrowZero"

--- a/dashboards-observability/public/components/common/search/search.tsx
+++ b/dashboards-observability/public/components/common/search/search.tsx
@@ -112,7 +112,7 @@ export const Search = (props: any) => {
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-        <EuiButtonIcon iconType='documents' href='https://opensearch.org/docs/latest/search-plugins/ppl/commands/'/>
+        <EuiButtonIcon iconType='iInCircle' iconSize='l' href='https://opensearch.org/docs/latest/search-plugins/ppl/commands/'/>
         </EuiFlexItem>
         <EuiFlexItem
           className="euiFlexItem--flexGrowZero"


### PR DESCRIPTION
### Description
Added a help icon next to search bar that redirects to OpenSearch documentation on PPL

### Issues Resolved
There was no easy way to access documentation as users wrote queries.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
