### PR TITLE
Added aggregate functions to autocomplete

### DIFF
--- a/dashboards-observability/public/components/common/search/autocomplete.tsx
+++ b/dashboards-observability/public/components/common/search/autocomplete.tsx
@@ -57,6 +57,10 @@ const statsCommands = [
   { label: 'avg(' },
   { label: 'max(' },
   { label: 'min(' },
+  { label: 'var_samp(' },
+  { label: 'var_pop(' },
+  { label: 'stddev_samp(' },
+  { label: 'stddev_pop(' },
 ];
 
 // Function to create the array of objects to be suggested


### PR DESCRIPTION
Signed-off by: Eugene Lee <eugenesk@amazon.com>

### Description
Aggregate functions, var_samp, var_pop, stddev_samp, stddev_pop are added to suggestions that follow stats

### Issues Resolved
Missing aggregate functions

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
