### PR TITLE
Suggestions are shown in dark mode if settings change

### DIFF
--- a/dashboards-observability/public/components/common/search/autocomplete.tsx
+++ b/dashboards-observability/public/components/common/search/autocomplete.tsx
@@ -23,6 +23,7 @@ import { IQueryBarProps } from './search';
 import { getDataValueQuery } from './queries/data_queries';
 import { isEmpty, isEqual } from 'lodash';
 import DSLService from 'public/services/requests/dsl';
+import { uiSettingsService } from '../../../../common/utils';
 
 let currIndex: string = '';
 let currField: string = '';
@@ -355,7 +356,7 @@ export function Autocomplete({
           autocompleteState.collections.map((collection, index) => {
             const { source, items } = collection;
             return (
-              <div key={`scrollable-${index}`} className="aa-PanelLayout aa-Panel--scrollable">
+              <div key={`scrollable-${index}`} className="aa-PanelLayout aa-Panel--scrollable" style={uiSettingsService.get('theme:darkMode') ? {backgroundColor: '#1D1E24'} : {}}>
                 <div key={`source-${index}`} className="aa-Source">
                   {items.length > 0 && (
                     <ul className="aa-List" {...autocomplete.getListProps()}>
@@ -369,6 +370,7 @@ export function Autocomplete({
                               item,
                               source,
                             })}
+                            style={uiSettingsService.get('theme:darkMode') ? {color: '#DFE5EF'}: {}}
                           >
                             <div className="aa-ItemWrapper">
                               <div className="aa-ItemContent">


### PR DESCRIPTION
Signed-off by: Eugene Lee <eugenesk@amazon.com>

### Description
In dark mode, the suggestions are also shown to match dark mode. 

### Issues Resolved
The suggestions were showing up in the regular colors even in dark mode.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
