### PR TITLE
Support dark mode for notebooks and other style improvements

### DIFF
--- a/dashboards-observability/public/components/notebooks/components/notebook.tsx
+++ b/dashboards-observability/public/components/notebooks/components/notebook.tsx
@@ -379,7 +379,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
       });
   };
 
-  // Backend call to add a paragraph
+  // Backend call to add a paragraph, switch to "view both" if in output only view
   addPara = (index: number, newParaContent: string, inpType: string) => {
     const addParaObj = {
       noteId: this.props.openedNoteId,
@@ -402,6 +402,8 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
 
         this.setState({ paragraphs, parsedPara });
         this.paragraphSelector(index);
+        if (this.state.selectedViewId === 'output_only')
+          this.setState({ selectedViewId: 'view_both' });
       })
       .catch((err) => {
         this.props.setToast(
@@ -994,41 +996,41 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
             </EuiFlexGroup>
             {this.state.parsedPara.length > 0 ? (
               <>
-                  <PanelWrapper>
-                    {this.state.parsedPara.map((para: ParaType, index: number) => (
-                      <div
-                        ref={this.state.parsedPara[index].paraDivRef}
-                        key={`para_div_${para.uniqueId}`}
-                        style={panelStyles}
-                      >
-                        <Paragraphs
-                          ref={this.state.parsedPara[index].paraRef}
-                          para={para}
-                          setPara={(para: ParaType) => this.setPara(para, index)}
-                          dateModified={this.state.paragraphs[index]?.dateModified}
-                          index={index}
-                          paraCount={this.state.parsedPara.length}
-                          paragraphSelector={this.paragraphSelector}
-                          textValueEditor={this.textValueEditor}
-                          handleKeyPress={this.handleKeyPress}
-                          addPara={this.addPara}
-                          DashboardContainerByValueRenderer={
-                            this.props.DashboardContainerByValueRenderer
-                          }
-                          deleteVizualization={this.deleteVizualization}
-                          http={this.props.http}
-                          selectedViewId={this.state.selectedViewId}
-                          setSelectedViewId={this.updateView}
-                          deletePara={this.showDeleteParaModal}
-                          runPara={this.updateRunParagraph}
-                          clonePara={this.cloneParaButton}
-                          movePara={this.movePara}
-                          showQueryParagraphError={this.state.showQueryParagraphError}
-                          queryParagraphErrorMessage={this.state.queryParagraphErrorMessage}
-                        />
-                      </div>
-                    ))}
-                  </PanelWrapper>
+                <PanelWrapper>
+                  {this.state.parsedPara.map((para: ParaType, index: number) => (
+                    <div
+                      ref={this.state.parsedPara[index].paraDivRef}
+                      key={`para_div_${para.uniqueId}`}
+                      style={panelStyles}
+                    >
+                      <Paragraphs
+                        ref={this.state.parsedPara[index].paraRef}
+                        para={para}
+                        setPara={(para: ParaType) => this.setPara(para, index)}
+                        dateModified={this.state.paragraphs[index]?.dateModified}
+                        index={index}
+                        paraCount={this.state.parsedPara.length}
+                        paragraphSelector={this.paragraphSelector}
+                        textValueEditor={this.textValueEditor}
+                        handleKeyPress={this.handleKeyPress}
+                        addPara={this.addPara}
+                        DashboardContainerByValueRenderer={
+                          this.props.DashboardContainerByValueRenderer
+                        }
+                        deleteVizualization={this.deleteVizualization}
+                        http={this.props.http}
+                        selectedViewId={this.state.selectedViewId}
+                        setSelectedViewId={this.updateView}
+                        deletePara={this.showDeleteParaModal}
+                        runPara={this.updateRunParagraph}
+                        clonePara={this.cloneParaButton}
+                        movePara={this.movePara}
+                        showQueryParagraphError={this.state.showQueryParagraphError}
+                        queryParagraphErrorMessage={this.state.queryParagraphErrorMessage}
+                      />
+                    </div>
+                  ))}
+                </PanelWrapper>
                 {this.state.selectedViewId !== 'output_only' && (
                   <EuiPopover
                     panelPaddingSize="none"

--- a/dashboards-observability/public/components/notebooks/components/notebook.tsx
+++ b/dashboards-observability/public/components/notebooks/components/notebook.tsx
@@ -43,7 +43,6 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import { Cells } from '@nteract/presentational-components';
 import CSS from 'csstype';
 import moment from 'moment';
 import queryString from 'query-string';
@@ -995,7 +994,6 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
             </EuiFlexGroup>
             {this.state.parsedPara.length > 0 ? (
               <>
-                <Cells>
                   <PanelWrapper>
                     {this.state.parsedPara.map((para: ParaType, index: number) => (
                       <div
@@ -1031,7 +1029,6 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                       </div>
                     ))}
                   </PanelWrapper>
-                </Cells>
                 {this.state.selectedViewId !== 'output_only' && (
                   <EuiPopover
                     panelPaddingSize="none"

--- a/dashboards-observability/public/components/notebooks/components/paragraph_components/para_input.tsx
+++ b/dashboards-observability/public/components/notebooks/components/paragraph_components/para_input.tsx
@@ -87,7 +87,7 @@ export const ParaInput = (props: {
 
   const renderParaInput = () => {
     return (
-      <>
+      <div style={{ width: '100%' }}>
         {/* If the para is selected show the editor else display the code in the paragraph */}
         {para.isSelected ? (
           <EuiTextArea
@@ -106,14 +106,14 @@ export const ParaInput = (props: {
           />
         ) : (
           <EuiCodeBlock
-            language={para.inp.slice(0, 4) === '%sql' ? 'sql' : 'md'}
+            language={para.inp.match(/^%(sql|md)/)?.[1]}
+            overflowHeight={200}
             paddingSize="s"
-            isCopyable
           >
             {para.inp}
           </EuiCodeBlock>
         )}
-      </>
+      </div>
     );
   };
 

--- a/dashboards-observability/public/components/notebooks/components/paragraph_components/para_input.tsx
+++ b/dashboards-observability/public/components/notebooks/components/paragraph_components/para_input.tsx
@@ -27,6 +27,7 @@
 import {
   EuiButton,
   EuiButtonEmpty,
+  EuiCodeBlock,
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
@@ -46,7 +47,7 @@ import {
   EuiText,
   EuiTextArea,
 } from '@elastic/eui';
-import { Input, Prompt, Source } from '@nteract/presentational-components';
+import { Input, Prompt } from '@nteract/presentational-components';
 import { uiSettingsService } from '../../../../../common/utils';
 import React, { useState } from 'react';
 import { ParaType } from '../../../../../common/types/notebooks';
@@ -86,7 +87,7 @@ export const ParaInput = (props: {
 
   const renderParaInput = () => {
     return (
-      <Source language={para.lang}>
+      <>
         {/* If the para is selected show the editor else display the code in the paragraph */}
         {para.isSelected ? (
           <EuiTextArea
@@ -104,9 +105,15 @@ export const ParaInput = (props: {
             autoFocus
           />
         ) : (
-          para.inp
+          <EuiCodeBlock
+            language={para.inp.slice(0, 4) === '%sql' ? 'sql' : 'md'}
+            paddingSize="s"
+            isCopyable
+          >
+            {para.inp}
+          </EuiCodeBlock>
         )}
-      </Source>
+      </>
     );
   };
 

--- a/dashboards-observability/public/components/notebooks/components/paragraph_components/para_output.tsx
+++ b/dashboards-observability/public/components/notebooks/components/paragraph_components/para_output.tsx
@@ -165,11 +165,12 @@ export const ParaOutput = (props: {
   const { para, DashboardContainerByValueRenderer, visInput, setVisInput } = props;
 
   return (
-    <>
-      {!para.isOutputHidden &&
-        para.typeOut.map((typeOut: string, tIdx: number) =>
+    !para.isOutputHidden && (
+      <>
+        {para.typeOut.map((typeOut: string, tIdx: number) =>
           outputBody(para.uniqueId + '_paraOutputBody', typeOut, para.out[tIdx])
         )}
-    </>
+      </>
+    )
   );
 };

--- a/dashboards-observability/public/components/notebooks/components/paragraph_components/para_output.tsx
+++ b/dashboards-observability/public/components/notebooks/components/paragraph_components/para_output.tsx
@@ -27,7 +27,6 @@
 import { EuiCodeBlock, EuiSpacer, EuiText } from '@elastic/eui';
 import MarkdownRender from '@nteract/markdown';
 import { Media } from '@nteract/outputs';
-import { Outputs } from '@nteract/presentational-components';
 import moment from 'moment';
 import React, { useState } from 'react';
 import {
@@ -166,10 +165,11 @@ export const ParaOutput = (props: {
   const { para, DashboardContainerByValueRenderer, visInput, setVisInput } = props;
 
   return (
-    <Outputs hidden={para.isOutputHidden}>
-      {para.typeOut.map((typeOut: string, tIdx: number) =>
-        outputBody(para.uniqueId + '_paraOutputBody', typeOut, para.out[tIdx])
-      )}
-    </Outputs>
+    <>
+      {!para.isOutputHidden &&
+        para.typeOut.map((typeOut: string, tIdx: number) =>
+          outputBody(para.uniqueId + '_paraOutputBody', typeOut, para.out[tIdx])
+        )}
+    </>
   );
 };

--- a/dashboards-observability/public/components/notebooks/components/paragraph_components/paragraphs.tsx
+++ b/dashboards-observability/public/components/notebooks/components/paragraph_components/paragraphs.tsx
@@ -52,6 +52,7 @@ import { ViewMode } from '../../../../../../../src/plugins/embeddable/public';
 import { NOTEBOOKS_API_PREFIX } from '../../../../../common/constants/notebooks';
 import { UI_DATE_FORMAT } from '../../../../../common/constants/shared';
 import { ParaType } from '../../../../../common/types/notebooks';
+import { uiSettingsService } from '../../../../../common/utils';
 import { ParaInput } from './para_input';
 import { ParaOutput } from './para_output';
 
@@ -479,6 +480,10 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
     </EuiText>
   );
 
+  const paraClass = `notebooks-paragraph notebooks-paragraph-${
+    uiSettingsService.get('theme:darkMode') ? 'dark' : 'light'
+  }`;
+
   return (
     <>
       <EuiPanel>
@@ -486,7 +491,7 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
           para.isVizualisation ? 'OpenSearch Dashboards visualization' : 'Code block',
           index
         )}
-        <div key={index} onClick={() => paragraphSelector(index)}>
+        <div key={index} className={paraClass} onClick={() => paragraphSelector(index)}>
           {para.isInputExpanded && (
             <>
               <EuiSpacer size="s" />

--- a/dashboards-observability/public/components/notebooks/components/paragraph_components/paragraphs.tsx
+++ b/dashboards-observability/public/components/notebooks/components/paragraph_components/paragraphs.tsx
@@ -537,7 +537,9 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
           {props.selectedViewId !== 'input_only' && isOutputAvailable && (
             <>
               <EuiHorizontalRule margin="none" />
-              <div style={{ opacity: para.isOutputStale ? 0.5 : 1 }}>{paraOutput}</div>
+              <div style={{ opacity: para.isOutputStale ? 0.5 : 1, padding: '15px' }}>
+                {paraOutput}
+              </div>
             </>
           )}
         </div>

--- a/dashboards-observability/public/components/notebooks/components/paragraph_components/paragraphs.tsx
+++ b/dashboards-observability/public/components/notebooks/components/paragraph_components/paragraphs.tsx
@@ -41,7 +41,6 @@ import {
   EuiText,
   htmlIdGenerator,
 } from '@elastic/eui';
-import { Cell } from '@nteract/presentational-components';
 import moment from 'moment';
 import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 import { CoreStart } from '../../../../../../../src/core/public';
@@ -487,7 +486,7 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
           para.isVizualisation ? 'OpenSearch Dashboards visualization' : 'Code block',
           index
         )}
-        <Cell key={index} onClick={() => paragraphSelector(index)}>
+        <div key={index} onClick={() => paragraphSelector(index)}>
           {para.isInputExpanded && (
             <>
               <EuiSpacer size="s" />
@@ -536,7 +535,7 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
               <div style={{ opacity: para.isOutputStale ? 0.5 : 1 }}>{paraOutput}</div>
             </>
           )}
-        </Cell>
+        </div>
       </EuiPanel>
     </>
   );

--- a/dashboards-observability/public/components/notebooks/index.scss
+++ b/dashboards-observability/public/components/notebooks/index.scss
@@ -23,11 +23,9 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
- 
+
 .editorArea {
   font-family: Dank Mono, Source Code Pro, Consolas, Courier New, Courier, monospace;
-  background-color: #fafafa;
-  color: #212121;
   font-size: 1em;
   border: none;
   width: 100%;
@@ -44,5 +42,19 @@
 }
 
 .markdown-output-text {
-  font-family: "Inter UI", -apple-system, system-ui, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-family: 'Inter UI', -apple-system, system-ui, 'Segoe UI', Helvetica, Arial, sans-serif,
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}
+
+.notebooks-paragraph button[aria-label='Expand'] {
+  display: none;
+}
+.notebooks-paragraph-dark .markdown-body {
+  pre.input {
+    background-color: #25262d !important;
+  }
+  code.language-text {
+    color: #e0e5ee !important;
+    background-color: #25262d !important;
+  }
 }

--- a/dashboards-observability/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/dashboards-observability/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -34,6 +34,7 @@ import {
   DATA_PREPPER_SERVICE_INDEX_NAME,
   TRACE_ANALYTICS_DOCUMENTATION_LINK,
 } from '../../../../../common/constants/trace_analytics';
+import { uiSettingsService } from '../../../../../common/utils';
 import { serviceMapColorPalette } from './color_palette';
 import { FilterType } from './filters/filters';
 import { ServiceObject } from './plots/service_map';
@@ -172,6 +173,7 @@ export function getServiceMapGraph(
     };
   });
   const edges: Array<{ from: number; to: number; color: string }> = [];
+  const edgeColor = uiSettingsService.get('theme:darkMode') ? '255, 255, 255' : '0, 0, 0';
   Object.keys(map).map((service) => {
     map[service].targetServices.map((target) => {
       edges.push({
@@ -179,8 +181,8 @@ export function getServiceMapGraph(
         to: map[target].id,
         color:
           relatedServices!.indexOf(service) >= 0 && relatedServices!.indexOf(target) >= 0
-            ? 'rgba(0, 0, 0, 1)'
-            : 'rgba(0, 0, 0, 0.3)',
+            ? `rgba(${edgeColor}, 1)`
+            : `rgba(${edgeColor}, 0.3)`,
       });
     });
   });

--- a/dashboards-observability/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/dashboards-observability/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -167,7 +167,7 @@ export function getServiceMapGraph(
       id: map[service].id,
       label: service,
       size: service === currService ? 30 : 15,
-      title: `<p>${service}</p><p>${message}</p>`,
+      title: `${service}\n\n${message}`,
       ...styleOptions,
     };
   });

--- a/dashboards-observability/public/components/trace_analytics/components/common/plots/service_map_scale.tsx
+++ b/dashboards-observability/public/components/trace_analytics/components/common/plots/service_map_scale.tsx
@@ -141,7 +141,7 @@ export function ServiceMapScale(props: {
               />
             </EuiFlexItem>
             <EuiFlexItem grow={false} style={{ marginRight: -30, marginLeft: -10 }}>
-              <EuiText style={{ transform: 'rotate(-90deg)', fontSize: '14px', color: '#444444' }}>
+              <EuiText style={{ transform: 'rotate(-90deg)', fontSize: '14px', color: '#808080' }}>
                 No match
               </EuiText>
             </EuiFlexItem>

--- a/dashboards-observability/public/components/trace_analytics/index.scss
+++ b/dashboards-observability/public/components/trace_analytics/index.scss
@@ -24,7 +24,7 @@
  *   permissions and limitations under the License.
  */
 
-@import '../../../node_modules/vis-network/dist/vis-network.min.css';
+@import '../../../node_modules/vis-network/dist/dist/vis-network.min.css';
 
 .overview-title {
   color: '#333333';

--- a/dashboards-observability/public/components/trace_analytics/index.scss
+++ b/dashboards-observability/public/components/trace_analytics/index.scss
@@ -24,7 +24,7 @@
  *   permissions and limitations under the License.
  */
 
-@import '../node_modules/vis-network/dist/vis-network.min.css';
+@import '../../../node_modules/vis-network/dist/dist/vis-network.min.css';
 
 .overview-title {
   color: '#333333';

--- a/dashboards-observability/public/components/trace_analytics/index.scss
+++ b/dashboards-observability/public/components/trace_analytics/index.scss
@@ -24,7 +24,7 @@
  *   permissions and limitations under the License.
  */
 
-@import '../../../node_modules/vis-network/dist/dist/vis-network.min.css';
+@import '../../../node_modules/vis-network/dist/vis-network.min.css';
 
 .overview-title {
   color: '#333333';

--- a/dashboards-observability/public/index.ts
+++ b/dashboards-observability/public/index.ts
@@ -9,6 +9,9 @@
  * GitHub history for details.
  */
 
+import './components/trace_analytics/index.scss';
+import './components/notebooks/index.scss'
+
 import { PluginInitializer, PluginInitializerContext } from '../../../src/core/public';
 import {
   ObservabilityPlugin

--- a/dashboards-observability/server/common/helpers/notebooks/sample_notebooks.ts
+++ b/dashboards-observability/server/common/helpers/notebooks/sample_notebooks.ts
@@ -62,14 +62,14 @@ For more information, refer to the [documentation](https://opensearch.org/docs/d
       {
         output: [
           {
-            result: 'Notebooks combine code blocks and visualizations for describing data. Code blocks support markdown, SQL, and PPL languages. Specify the input language on the first line using %[language type] syntax. For example, type %md for markdown, %sql for SQL, and %ppl for PPL. A sample visualization is shown below:',
+            result: 'Notebooks combine code blocks and visualizations for describing data. Code blocks support markdown, SQL, and PPL languages. Specify the input language on the first line using %\[language type\] syntax. For example, type %md for markdown, %sql for SQL, and %ppl for PPL. A sample visualization is shown below:',
             outputType: 'MARKDOWN',
             execution_time: '0 ms',
           },
         ],
         input: {
           inputText: `%md
-Notebooks combine code blocks and visualizations for describing data. Code blocks support markdown, SQL, and PPL languages. Specify the input language on the first line using %[language type] syntax. For example, type %md for markdown, %sql for SQL, and %ppl for PPL. A sample visualization is shown below:`,
+Notebooks combine code blocks and visualizations for describing data. Code blocks support markdown, SQL, and PPL languages. Specify the input language on the first line using %\[language type\] syntax. For example, type %md for markdown, %sql for SQL, and %ppl for PPL. A sample visualization is shown below:`,
           inputType: 'MARKDOWN',
         },
         dateCreated: dateString,

--- a/dashboards-observability/yarn.lock
+++ b/dashboards-observability/yarn.lock
@@ -143,13 +143,6 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@egjs/hammerjs@^2.0.15":
-  version "2.0.17"
-  resolved "https://registry.yarnpkg.com/@egjs/hammerjs/-/hammerjs-2.0.17.tgz#5dc02af75a6a06e4c2db0202cae38c9263895124"
-  integrity sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==
-  dependencies:
-    "@types/hammerjs" "^2.0.36"
-
 "@hypnosphi/create-react-context@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz#f8bfebdc7665f5d426cba3753e0e9c7d3154d7c6"
@@ -244,11 +237,6 @@
   dependencies:
     "@types/cheerio" "*"
     "@types/react" "*"
-
-"@types/hammerjs@^2.0.36":
-  version "2.0.40"
-  resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.40.tgz#ded0240b6ea1ad7afc1e60374c49087aaea5dbd8"
-  integrity sha512-VbjwR1fhsn2h2KXAY4oy1fm7dCxaKy0D+deTb8Ilc3Eo3rc5+5eA4rfYmZaHgNJKxVyI0f6WIXzO2zLkVmQPHA==
 
 "@types/hast@^2.0.0":
   version "2.3.4"
@@ -733,11 +721,6 @@ common-tags@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
   integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
-
-component-emitter@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
-  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1900,11 +1883,6 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-keycharm@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/keycharm/-/keycharm-0.2.0.tgz#fa6ea2e43b90a68028843d27f2075d35a8c3e6f9"
-  integrity sha1-+m6i5DuQpoAohD0n8gddNajD5vk=
-
 lazy-ass@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
@@ -2089,12 +2067,7 @@ mkdirp@^0.5.1, mkdirp@^0.5.4:
   dependencies:
     minimist "^1.2.5"
 
-moment@2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
-
-moment@^2.24.0, moment@^2.27.0:
+moment@^2.27.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
@@ -2452,14 +2425,15 @@ react-base16-styling@^0.7.0:
     pure-color "^1.3.0"
 
 react-graph-vis@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/react-graph-vis/-/react-graph-vis-1.0.5.tgz#4aee3130db73a69a577a99e30a9126bd0e6d59cd"
-  integrity sha512-y7+eHcwj7GryRoY+ZawwsDmS8OMeJ8Gpzmzejqwz+T2qg6IYTk1bod42H5g3J2zzHcPaqAZpwxZG3d3YB4nBwQ==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/react-graph-vis/-/react-graph-vis-1.0.7.tgz#55b934100c5235e7cc0e8721646c21246e4b7d75"
+  integrity sha512-FI35zlBMKU22JEvG1ukd1DDwW185y4YrDvHm6Bom9EGdA+UNMrZrIV/lyPIRWPcRkzbKaA1w1NvOYcRApD4KdQ==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.10"
     uuid "^2.0.1"
-    vis-network "^5.1.1"
+    vis-data "^7.1.2"
+    vis-network "^9.0.0"
 
 react-is@^16.13.1, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
@@ -2971,11 +2945,6 @@ through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-timsort@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
-  integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
-
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -3204,36 +3173,15 @@ vfile@^2.0.0:
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
 
-vis-data@^6.1.1:
-  version "6.6.1"
-  resolved "https://registry.yarnpkg.com/vis-data/-/vis-data-6.6.1.tgz#2aa52e46c305ad46bb7abe6e7634e2eecd743b15"
-  integrity sha512-xmujDB2Dzf8T04rGFJ9OP4OA6zRVrz8R9hb0CVKryBrZRCljCga9JjSfgctA8S7wdZu7otDtUIwX4ZOgfV/57w==
+vis-data@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/vis-data/-/vis-data-7.1.2.tgz#b7d076ac79cb54f7c5e9c80f5b03b93cc8cc1fda"
+  integrity sha512-RPSegFxEcnp3HUEJSzhS2vBdbJ2PSsrYYuhRlpHp2frO/MfRtTYbIkkLZmPkA/Sg3pPfBlR235gcoKbtdm4mbw==
 
-vis-network@^5.1.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/vis-network/-/vis-network-5.4.1.tgz#e0e33d23775e834f4cfd961bd7b92bf11df097c6"
-  integrity sha512-hUJlFWoCmLup6IxoXCr//OO2ZCkC8jrXEkkHLG1DhBgB54Y3K33+e5q4tc436inMlGzfqqaKTIToNbOGr8Szww==
-  dependencies:
-    "@egjs/hammerjs" "^2.0.15"
-    component-emitter "^1.3.0"
-    keycharm "^0.2.0"
-    moment "^2.24.0"
-    timsort "^0.3.0"
-    vis-data "^6.1.1"
-    vis-util "^1.1.6"
-
-vis-util@^1.1.6:
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/vis-util/-/vis-util-1.1.10.tgz#1c0ebb17ad5139959122dcd12aae54a4e173846a"
-  integrity sha512-8hGSxsFi2ogYYweClQyITzWnirWgQ8p0i9M4d3OXMuUO8vjXrf+2zHOYI9OZbtUduxAWuMEePnS9BXDtPJmJ7Q==
-  dependencies:
-    moment "2.24.0"
-    vis-uuid "1.1.3"
-
-vis-uuid@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/vis-uuid/-/vis-uuid-1.1.3.tgz#2f53ff35e9e026b0ec93bc433ce685c40c2f784c"
-  integrity sha512-2B6XdY1bkzbUh+TugmnAaFa61KO9R5pzBzIuFIm8a9FrkbxIdSmQXV+FbfkL8QunkQV/bT0JDLQ2puqCS2+0Og==
+vis-network@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/vis-network/-/vis-network-9.1.0.tgz#511db833b68060f279bedc4a852671261d40204e"
+  integrity sha512-rx96L144RJWcqOa6afjiFyxZKUerRRbT/YaNMpsusHdwzxrVTO2LlduR45PeJDEztrAf3AU5l2zmiG+1ydUZCw==
 
 warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"

--- a/dashboards-observability/yarn.lock
+++ b/dashboards-observability/yarn.lock
@@ -143,6 +143,13 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@egjs/hammerjs@^2.0.15":
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/@egjs/hammerjs/-/hammerjs-2.0.17.tgz#5dc02af75a6a06e4c2db0202cae38c9263895124"
+  integrity sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==
+  dependencies:
+    "@types/hammerjs" "^2.0.36"
+
 "@hypnosphi/create-react-context@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz#f8bfebdc7665f5d426cba3753e0e9c7d3154d7c6"
@@ -237,6 +244,11 @@
   dependencies:
     "@types/cheerio" "*"
     "@types/react" "*"
+
+"@types/hammerjs@^2.0.36":
+  version "2.0.40"
+  resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.40.tgz#ded0240b6ea1ad7afc1e60374c49087aaea5dbd8"
+  integrity sha512-VbjwR1fhsn2h2KXAY4oy1fm7dCxaKy0D+deTb8Ilc3Eo3rc5+5eA4rfYmZaHgNJKxVyI0f6WIXzO2zLkVmQPHA==
 
 "@types/hast@^2.0.0":
   version "2.3.4"
@@ -721,6 +733,11 @@ common-tags@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
   integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
+
+component-emitter@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
+  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1883,6 +1900,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+keycharm@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/keycharm/-/keycharm-0.2.0.tgz#fa6ea2e43b90a68028843d27f2075d35a8c3e6f9"
+  integrity sha1-+m6i5DuQpoAohD0n8gddNajD5vk=
+
 lazy-ass@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
@@ -2067,7 +2089,12 @@ mkdirp@^0.5.1, mkdirp@^0.5.4:
   dependencies:
     minimist "^1.2.5"
 
-moment@^2.27.0:
+moment@2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
+moment@^2.24.0, moment@^2.27.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
@@ -2425,15 +2452,14 @@ react-base16-styling@^0.7.0:
     pure-color "^1.3.0"
 
 react-graph-vis@^1.0.5:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/react-graph-vis/-/react-graph-vis-1.0.7.tgz#55b934100c5235e7cc0e8721646c21246e4b7d75"
-  integrity sha512-FI35zlBMKU22JEvG1ukd1DDwW185y4YrDvHm6Bom9EGdA+UNMrZrIV/lyPIRWPcRkzbKaA1w1NvOYcRApD4KdQ==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/react-graph-vis/-/react-graph-vis-1.0.5.tgz#4aee3130db73a69a577a99e30a9126bd0e6d59cd"
+  integrity sha512-y7+eHcwj7GryRoY+ZawwsDmS8OMeJ8Gpzmzejqwz+T2qg6IYTk1bod42H5g3J2zzHcPaqAZpwxZG3d3YB4nBwQ==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.10"
     uuid "^2.0.1"
-    vis-data "^7.1.2"
-    vis-network "^9.0.0"
+    vis-network "^5.1.1"
 
 react-is@^16.13.1, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
@@ -2945,6 +2971,11 @@ through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
+timsort@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
+  integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -3173,15 +3204,36 @@ vfile@^2.0.0:
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
 
-vis-data@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/vis-data/-/vis-data-7.1.2.tgz#b7d076ac79cb54f7c5e9c80f5b03b93cc8cc1fda"
-  integrity sha512-RPSegFxEcnp3HUEJSzhS2vBdbJ2PSsrYYuhRlpHp2frO/MfRtTYbIkkLZmPkA/Sg3pPfBlR235gcoKbtdm4mbw==
+vis-data@^6.1.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/vis-data/-/vis-data-6.6.1.tgz#2aa52e46c305ad46bb7abe6e7634e2eecd743b15"
+  integrity sha512-xmujDB2Dzf8T04rGFJ9OP4OA6zRVrz8R9hb0CVKryBrZRCljCga9JjSfgctA8S7wdZu7otDtUIwX4ZOgfV/57w==
 
-vis-network@^9.0.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/vis-network/-/vis-network-9.1.0.tgz#511db833b68060f279bedc4a852671261d40204e"
-  integrity sha512-rx96L144RJWcqOa6afjiFyxZKUerRRbT/YaNMpsusHdwzxrVTO2LlduR45PeJDEztrAf3AU5l2zmiG+1ydUZCw==
+vis-network@^5.1.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/vis-network/-/vis-network-5.4.1.tgz#e0e33d23775e834f4cfd961bd7b92bf11df097c6"
+  integrity sha512-hUJlFWoCmLup6IxoXCr//OO2ZCkC8jrXEkkHLG1DhBgB54Y3K33+e5q4tc436inMlGzfqqaKTIToNbOGr8Szww==
+  dependencies:
+    "@egjs/hammerjs" "^2.0.15"
+    component-emitter "^1.3.0"
+    keycharm "^0.2.0"
+    moment "^2.24.0"
+    timsort "^0.3.0"
+    vis-data "^6.1.1"
+    vis-util "^1.1.6"
+
+vis-util@^1.1.6:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/vis-util/-/vis-util-1.1.10.tgz#1c0ebb17ad5139959122dcd12aae54a4e173846a"
+  integrity sha512-8hGSxsFi2ogYYweClQyITzWnirWgQ8p0i9M4d3OXMuUO8vjXrf+2zHOYI9OZbtUduxAWuMEePnS9BXDtPJmJ7Q==
+  dependencies:
+    moment "2.24.0"
+    vis-uuid "1.1.3"
+
+vis-uuid@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/vis-uuid/-/vis-uuid-1.1.3.tgz#2f53ff35e9e026b0ec93bc433ce685c40c2f784c"
+  integrity sha512-2B6XdY1bkzbUh+TugmnAaFa61KO9R5pzBzIuFIm8a9FrkbxIdSmQXV+FbfkL8QunkQV/bT0JDLQ2puqCS2+0Og==
 
 warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
### Description
- remove some notebooks nteract wrappers to support dark mode
- import style sheet for notebooks and trace analytics
- support dark mode in trace analytics service map
- switch notebooks to "view both" if adding paragraphs in output only view

### Issues Resolved
- #205 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
