### PR TITLE
Add toggle dark mode in observability side bar

### DIFF
--- a/dashboards-observability/common/utils/settings_service.ts
+++ b/dashboards-observability/common/utils/settings_service.ts
@@ -9,15 +9,23 @@
  * GitHub history for details.
  */
 
-import { IUiSettingsClient } from '../../../../src/core/public';
+import { IUiSettingsClient, NotificationsStart, ToastInput } from '../../../../src/core/public';
 
 let uiSettings: IUiSettingsClient;
+let notifications: NotificationsStart;
 
 export const uiSettingsService = {
-  init: (client: IUiSettingsClient) => {
+  init: (client: IUiSettingsClient, notificationsStart: NotificationsStart) => {
     uiSettings = client;
+    notifications = notificationsStart;
   },
   get: (key: string, defaultOverride?: any) => {
     return uiSettings?.get(key, defaultOverride) || '';
   },
+  set: (key: string, value: any) => {
+    return uiSettings?.set(key, value) || Promise.reject("uiSettings client not initialized.");
+  },
+  addToast: (toast: ToastInput) => {
+    return notifications.toasts.add(toast);
+  }
 };

--- a/dashboards-observability/opensearch_dashboards.json
+++ b/dashboards-observability/opensearch_dashboards.json
@@ -13,6 +13,7 @@
     "navigation",
     "uiActions",
     "dashboard",
-    "visualizations"
+    "visualizations",
+    "opensearchDashboardsReact"
   ]
 }

--- a/dashboards-observability/public/components/app.tsx
+++ b/dashboards-observability/public/components/app.tsx
@@ -17,7 +17,6 @@ import { CoreStart } from '../../../../src/core/public';
 import { observabilityID, observabilityTitle } from '../../common/constants/shared';
 import store from '../framework/redux/store';
 import { AppPluginStartDependencies } from '../types';
-import { renderPageWithSidebar } from './common/side_nav';
 import { Home as CustomPanelsHome } from './custom_panels/home';
 import { EventAnalytics } from './explorer/event_analytics';
 import { Main as NotebooksHome } from './notebooks/components/main';

--- a/dashboards-observability/public/components/common/side_nav.tsx
+++ b/dashboards-observability/public/components/common/side_nav.tsx
@@ -9,10 +9,23 @@
  * GitHub history for details.
  */
 
-import { EuiPage, EuiPageBody, EuiPageSideBar, EuiSideNav, EuiSideNavItemType } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPage,
+  EuiPageBody,
+  EuiPageSideBar,
+  EuiSideNav,
+  EuiSideNavItemType,
+  EuiSwitch,
+} from '@elastic/eui';
 import React from 'react';
+import { useState } from 'react';
+import { toMountPoint } from '../../../../../src/plugins/opensearch_dashboards_react/public';
+import { uiSettingsService } from '../../../common/utils';
 
-export const renderPageWithSidebar = (BodyComponent: React.ReactNode) => {
+export function ObservabilitySideBar(props: { children: React.ReactNode }) {
   // set items.isSelected based on location.hash passed in
   // tries to find an item where href is a prefix of the hash
   // if none will try to find an item where the hash is a prefix of href
@@ -74,13 +87,50 @@ export const renderPageWithSidebar = (BodyComponent: React.ReactNode) => {
     },
   ];
   setIsSelected(items, location.hash);
+  const [isDarkMode, setIsDarkMode] = useState(uiSettingsService.get('theme:darkMode'));
 
   return (
     <EuiPage>
       <EuiPageSideBar>
-        <EuiSideNav items={items} />
+        <EuiFlexGroup
+          direction="column"
+          justifyContent="spaceBetween"
+          style={{ height: '98%', minHeight: '80vh' }}
+          gutterSize="none"
+        >
+          <EuiFlexItem grow={10}>
+            <EuiSideNav items={items} />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiSwitch
+              label="Dark mode"
+              checked={isDarkMode}
+              onChange={() => {
+                uiSettingsService.set('theme:darkMode', !isDarkMode).then((resp) => {
+                  setIsDarkMode(!isDarkMode);
+                  uiSettingsService.addToast({
+                    title:
+                      'Changing dark mode setting requires you to reload the page to take effect.',
+                    text: toMountPoint(
+                      <>
+                        <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+                          <EuiFlexItem grow={false}>
+                            <EuiButton size="s" onClick={() => window.location.reload()}>
+                              Reload page
+                            </EuiButton>
+                          </EuiFlexItem>
+                        </EuiFlexGroup>
+                      </>
+                    ),
+                    color: 'success',
+                  });
+                });
+              }}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiPageSideBar>
-      <EuiPageBody>{BodyComponent}</EuiPageBody>
+      <EuiPageBody>{props.children}</EuiPageBody>
     </EuiPage>
   );
-};
+}

--- a/dashboards-observability/public/components/custom_panels/home.tsx
+++ b/dashboards-observability/public/components/custom_panels/home.tsx
@@ -11,7 +11,6 @@
 
 import { EuiBreadcrumb, EuiGlobalToastList, EuiLink } from '@elastic/eui';
 import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
-import { CustomPanelListType } from '../../../common/types/custom_panels';
 import _ from 'lodash';
 import React, { ReactChild, useState } from 'react';
 import { StaticContext } from 'react-router';
@@ -21,15 +20,16 @@ import {
   CUSTOM_PANELS_API_PREFIX,
   CUSTOM_PANELS_DOCUMENTATION_URL,
 } from '../../../common/constants/custom_panels';
-import { renderPageWithSidebar } from '../common/side_nav';
-import { CustomPanelTable } from './custom_panel_table';
-import { CustomPanelView } from './custom_panel_view';
-import { isNameValid } from './helpers/utils';
 import {
   EVENT_ANALYTICS,
   OBSERVABILITY_BASE,
   SAVED_OBJECTS,
 } from '../../../common/constants/shared';
+import { CustomPanelListType } from '../../../common/types/custom_panels';
+import { ObservabilitySideBar } from '../common/side_nav';
+import { CustomPanelTable } from './custom_panel_table';
+import { CustomPanelView } from './custom_panel_view';
+import { isNameValid } from './helpers/utils';
 
 /*
  * "Home" module is initial page for Operantional Panels
@@ -289,19 +289,21 @@ export const Home = ({ http, chrome, parentBreadcrumb, pplService, renderProps }
         exact
         path={renderProps.match.path}
         render={(props) => {
-          return renderPageWithSidebar(
-            <CustomPanelTable
-              loading={loading}
-              fetchCustomPanels={fetchCustomPanels}
-              customPanels={customPanelData}
-              createCustomPanel={createCustomPanel}
-              setBreadcrumbs={chrome.setBreadcrumbs}
-              parentBreadcrumb={parentBreadcrumb}
-              renameCustomPanel={renameCustomPanel}
-              cloneCustomPanel={cloneCustomPanel}
-              deleteCustomPanelList={deleteCustomPanelList}
-              addSamplePanels={addSamplePanels}
-            />
+          return (
+            <ObservabilitySideBar>
+              <CustomPanelTable
+                loading={loading}
+                fetchCustomPanels={fetchCustomPanels}
+                customPanels={customPanelData}
+                createCustomPanel={createCustomPanel}
+                setBreadcrumbs={chrome.setBreadcrumbs}
+                parentBreadcrumb={parentBreadcrumb}
+                renameCustomPanel={renameCustomPanel}
+                cloneCustomPanel={cloneCustomPanel}
+                deleteCustomPanelList={deleteCustomPanelList}
+                addSamplePanels={addSamplePanels}
+              />
+            </ObservabilitySideBar>
           );
         }}
       />

--- a/dashboards-observability/public/components/explorer/event_analytics.tsx
+++ b/dashboards-observability/public/components/explorer/event_analytics.tsx
@@ -9,15 +9,15 @@
  * GitHub history for details.
  */
 
-import React, { useState, ReactChild } from 'react';
-import { isEmpty } from 'lodash';
-import { HashRouter, Route, Switch } from 'react-router-dom';
-import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
 import { EuiGlobalToastList } from '@elastic/eui';
-import { LogExplorer } from './log_explorer';
-import { Home as EventExplorerHome } from './home';
-import { renderPageWithSidebar } from '../common/side_nav';
+import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
+import { isEmpty } from 'lodash';
+import React, { ReactChild, useState } from 'react';
+import { HashRouter, Route, Switch } from 'react-router-dom';
 import { RAW_QUERY } from '../../../common/constants/explorer';
+import { ObservabilitySideBar } from '../common/side_nav';
+import { Home as EventExplorerHome } from './home';
+import { LogExplorer } from './log_explorer';
 
 export const EventAnalytics = ({
   chrome,
@@ -29,7 +29,6 @@ export const EventAnalytics = ({
   http,
   ...props
 }: any) => {
-
   const [toasts, setToasts] = useState<Array<Toast>>([]);
 
   const eventAnalyticsBreadcrumb = {
@@ -46,10 +45,7 @@ export const EventAnalytics = ({
     let emptyTabId = '';
     for (let i = 0; i < tabIds.length; i++) {
       const tid = tabIds[i];
-      if (
-        isEmpty(queries[tid][RAW_QUERY]) &&
-        isEmpty(explorerData[tid])
-      ) {
+      if (isEmpty(queries[tid][RAW_QUERY]) && isEmpty(explorerData[tid])) {
         emptyTabId = tid;
         break;
       }
@@ -77,7 +73,7 @@ export const EventAnalytics = ({
                 {
                   text: 'Explorer',
                   href: `#/event_analytics/explorer`,
-                }
+                },
               ]);
               return (
                 <LogExplorer
@@ -104,17 +100,19 @@ export const EventAnalytics = ({
                 {
                   text: 'Home',
                   href: '#/event_analytics',
-                }
+                },
               ]);
-              return renderPageWithSidebar(
-                <EventExplorerHome 
-                  http={http}
-                  savedObjects={savedObjects}
-                  dslService={dslService}
-                  timestampUtils={timestampUtils}
-                  setToast={ setToast }
-                  getExistingEmptyTab={getExistingEmptyTab}
-                />
+              return (
+                <ObservabilitySideBar>
+                  <EventExplorerHome
+                    http={http}
+                    savedObjects={savedObjects}
+                    dslService={dslService}
+                    timestampUtils={timestampUtils}
+                    setToast={setToast}
+                    getExistingEmptyTab={getExistingEmptyTab}
+                  />
+                </ObservabilitySideBar>
               );
             }}
           />
@@ -122,4 +120,4 @@ export const EventAnalytics = ({
       </HashRouter>
     </>
   );
-}
+};

--- a/dashboards-observability/public/components/notebooks/components/main.tsx
+++ b/dashboards-observability/public/components/notebooks/components/main.tsx
@@ -31,8 +31,11 @@ import { Route, Switch } from 'react-router';
 import { HashRouter, RouteComponentProps } from 'react-router-dom';
 import { ChromeBreadcrumb, CoreStart } from '../../../../../../src/core/public';
 import { DashboardStart } from '../../../../../../src/plugins/dashboard/public';
-import { NOTEBOOKS_API_PREFIX, NOTEBOOKS_DOCUMENTATION_URL } from '../../../../common/constants/notebooks';
-import { renderPageWithSidebar } from '../../common/side_nav';
+import {
+  NOTEBOOKS_API_PREFIX,
+  NOTEBOOKS_DOCUMENTATION_URL,
+} from '../../../../common/constants/notebooks';
+import { ObservabilitySideBar } from '../../common/side_nav';
 import { Notebook } from './notebook';
 import { NoteTable } from './note_table';
 
@@ -339,8 +342,8 @@ export class Main extends React.Component<MainProps, MainState> {
             />
             <Route
               path="/notebooks"
-              render={(props) =>
-                renderPageWithSidebar(
+              render={(props) => (
+                <ObservabilitySideBar>
                   <NoteTable
                     loading={this.state.loading}
                     fetchNotebooks={this.fetchNotebooks}
@@ -354,8 +357,8 @@ export class Main extends React.Component<MainProps, MainState> {
                     setBreadcrumbs={this.props.setBreadcrumbs}
                     setToast={this.setToast}
                   />
-                )
-              }
+                </ObservabilitySideBar>
+              )}
             />
           </Switch>
         </>

--- a/dashboards-observability/public/components/trace_analytics/home.tsx
+++ b/dashboards-observability/public/components/trace_analytics/home.tsx
@@ -11,8 +11,13 @@
 
 import React, { useEffect, useState } from 'react';
 import { Route, RouteComponentProps } from 'react-router-dom';
-import { ChromeBreadcrumb, ChromeStart, HttpStart } from '../../../../../src/core/public';
-import { renderPageWithSidebar } from '../common/side_nav';
+import {
+  ChromeBreadcrumb,
+  ChromeStart,
+  CoreStart,
+  HttpStart,
+} from '../../../../../src/core/public';
+import { ObservabilitySideBar } from '../common/side_nav';
 import { FilterType } from './components/common/filters/filters';
 import { SearchBarProps } from './components/common/search_bar';
 import { Dashboard } from './components/dashboard';
@@ -87,12 +92,20 @@ export const Home = (props: HomeProps) => {
       <Route
         exact
         path={['/', '/trace_analytics', '/trace_analytics/home']}
-        render={(routerProps) => renderPageWithSidebar(<Dashboard {...commonProps} />)}
+        render={(routerProps) => (
+          <ObservabilitySideBar>
+            <Dashboard {...commonProps} />
+          </ObservabilitySideBar>
+        )}
       />
       <Route
         exact
         path="/trace_analytics/traces"
-        render={(routerProps) => renderPageWithSidebar(<Traces {...commonProps} />)}
+        render={(routerProps) => (
+          <ObservabilitySideBar>
+            <Traces {...commonProps} />
+          </ObservabilitySideBar>
+        )}
       />
       <Route
         path="/trace_analytics/traces/:id+"
@@ -108,7 +121,11 @@ export const Home = (props: HomeProps) => {
       <Route
         exact
         path="/trace_analytics/services"
-        render={(routerProps) => renderPageWithSidebar(<Services {...commonProps} />)}
+        render={(routerProps) => (
+          <ObservabilitySideBar>
+            <Services {...commonProps} />
+          </ObservabilitySideBar>
+        )}
       />
       <Route
         path="/trace_analytics/services/:id+"

--- a/dashboards-observability/public/plugin.ts
+++ b/dashboards-observability/public/plugin.ts
@@ -25,7 +25,7 @@ import { uiSettingsService } from '../common/utils';
 
 export class ObservabilityPlugin implements Plugin<ObservabilitySetup, ObservabilityStart> {
   public setup(core: CoreSetup): ObservabilitySetup {
-    uiSettingsService.init(core.uiSettings);
+    uiSettingsService.init(core.uiSettings, core.notifications);
 
     // redirect legacy notebooks URL to current URL under observability
     if (window.location.pathname.includes('notebooks-dashboards')) {


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Add a dark mode toggle button in side bar at bottom of the page. It will show a toast to ask user to reload.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
