### PR TITLE
Use parent height instead of view port height for nav bar

### DIFF
--- a/dashboards-observability/public/components/common/side_nav.tsx
+++ b/dashboards-observability/public/components/common/side_nav.tsx
@@ -95,10 +95,10 @@ export function ObservabilitySideBar(props: { children: React.ReactNode }) {
         <EuiFlexGroup
           direction="column"
           justifyContent="spaceBetween"
-          style={{ height: '100%', minHeight: '80vh' }}
+          style={{ height: '100%' }}
           gutterSize="none"
         >
-          <EuiFlexItem grow={10}>
+          <EuiFlexItem>
             <EuiSideNav items={items} />
           </EuiFlexItem>
           <EuiFlexItem grow={false} style={{ marginBottom: 20 }}>
@@ -109,8 +109,7 @@ export function ObservabilitySideBar(props: { children: React.ReactNode }) {
                 uiSettingsService.set('theme:darkMode', !isDarkMode).then((resp) => {
                   setIsDarkMode(!isDarkMode);
                   uiSettingsService.addToast({
-                    title:
-                      'Theme setting changes require you to reload the page to take effect.',
+                    title: 'Theme setting changes require you to reload the page to take effect.',
                     text: toMountPoint(
                       <>
                         <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
remove using view port height to position theme toggle button, otherwise it breaks content on the right by increasing height of the page
![image](https://user-images.githubusercontent.com/28062824/141018328-fc5df93b-d364-4b25-b44b-98e2b1cab8f8.png)

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
