### PR TITLE
Add border around suggestions

### DIFF
--- a/dashboards-observability/public/components/common/search/autocomplete.tsx
+++ b/dashboards-observability/public/components/common/search/autocomplete.tsx
@@ -396,7 +396,7 @@ export function Autocomplete({
               const { source, items } = collection;
               const filteredItems = items.filter((item, index) => { return items.findIndex(i => i.itemName === item.itemName) === index })
               return (
-                <div key={`scrollable-${index}`} className="aa-PanelLayout aa-Panel--scrollable" style={uiSettingsService.get('theme:darkMode') ? {backgroundColor: '#1D1E24'} : {}}>
+                <div key={`scrollable-${index}`} className="aa-PanelLayout aa-Panel--scrollable" style={uiSettingsService.get('theme:darkMode') ? {backgroundColor: '#1D1E24', border: '2px groove #383444'} : {}}>
                   <div key={`source-${index}`} className="aa-Source">
                     {items.length > 0 && (
                       <ul className="aa-List" {...autocomplete.getListProps()}>


### PR DESCRIPTION
### Description
A border is added around the suggestions so that they are more visible in dark mode. 

![suggestions with border](https://user-images.githubusercontent.com/92330893/141163107-fd7f0369-cff7-4e10-a557-4b772468f203.png)

### Issues Resolved
In dark mode, the boundary of the suggestions was not distinct. 

![suggestions without border](https://user-images.githubusercontent.com/92330893/141163176-80e403c4-7b42-4fc5-b62b-f0e750ee60db.png)



### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
