### PR TITLE
Add missing itemName properties

### DIFF
--- a/dashboards-observability/public/components/common/search/autocomplete.tsx
+++ b/dashboards-observability/public/components/common/search/autocomplete.tsx
@@ -149,7 +149,7 @@ const getSuggestions = async (str: string, dslService: DSLService) => {
       inMatch = true;
       currField = splittedModel[splittedModel.length - 2];
       currFieldType = fieldsFromBackend.find((field) => field.label === currField)?.type;
-      return [{ label: str + ',', input: str, suggestion: ','}].filter(
+      return [{ label: str + ',', input: str, suggestion: ',', itemName: ','}].filter(
         ({ suggestion }) => suggestion.startsWith(prefix) && prefix !== suggestion
       );
     } else if (splittedModel[splittedModel.length - 2] === 'search') {
@@ -242,7 +242,7 @@ const getSuggestions = async (str: string, dslService: DSLService) => {
       ].filter(({ label }) => label.toLowerCase().startsWith(lowerPrefix) && lowerPrefix.localeCompare(label.toLowerCase()));
     }  else if (inMatch) {
       inMatch = false;
-      return [{ label: str + ')', input: str, suggestion: ')' }].filter(
+      return [{ label: str + ')', input: str, suggestion: ')', itemName: ')' }].filter(
       ({ suggestion }) => suggestion.startsWith(prefix) && prefix !== suggestion
       );
     }


### PR DESCRIPTION
Signed-off-by: Eugene Lee <eugenesk@amazon.com>

### Description
Added missing itemName property that is called later in the render

### Issues Resolved
Suggestions missing the itemName property would error because they would be undefined when called in the render.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
