### PR TITLE
Add event analytics permission toast

### DIFF
--- a/dashboards-observability/public/components/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/explorer/explorer.tsx
@@ -20,6 +20,7 @@ import {
   EuiTabbedContentTab,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLink,
 } from '@elastic/eui';
 import dateMath from '@elastic/datemath';
 import classNames from 'classnames';
@@ -45,7 +46,8 @@ import {
   SAVED_QUERY,
   SAVED_VISUALIZATION,
   SAVED_OBJECT_ID,
-  SAVED_OBJECT_TYPE
+  SAVED_OBJECT_TYPE,
+  EVENT_ANALYTICS_DOCUMENTATION_URL,
 } from '../../../common/constants/explorer';
 import { PPL_STATS_REGEX, PPL_NEWLINE_REGEX } from '../../../common/constants/shared';
 import { getIndexPatternFromRawQuery, insertDateRangeToQuery } from '../../../common/utils';
@@ -241,6 +243,9 @@ export const Explorer = ({
       const savedTimestamps = await savedObjects.fetchSavedObjects({
         objectId: curIndex
       }).catch((error: any) => {
+        if (error?.body?.statusCode === 403) {
+          showPermissionErrorToast();
+        }
         console.log(`Unable to get saved timestamp for this index: ${error.message}`);
       });
       if (
@@ -329,6 +334,16 @@ export const Explorer = ({
       }
     }));
   }
+
+  const showPermissionErrorToast = () => {
+    setToast(
+      'Please ask your administrator to enable Event Analytics for you.',
+      'danger',
+      <EuiLink href={EVENT_ANALYTICS_DOCUMENTATION_URL} target="_blank">
+        Documentation
+      </EuiLink>
+    );
+  };
 
   const handleTimeRangePickerRefresh = () => {
     handleQuerySearch();
@@ -699,7 +714,11 @@ export const Explorer = ({
           history.replace(`/event_analytics/explorer/${res['objectId']}`);
         })
         .catch((error: any) => { 
-          setToast(`Cannot save query '${selectedPanelNameRef.current}', error: ${error.message}`, 'danger');
+          if (error?.body?.statusCode === 403) {
+            showPermissionErrorToast();
+          } else {
+            setToast(`Cannot save query '${selectedPanelNameRef.current}', error: ${error.message}`, 'danger');
+          }
         });
       }
       // to-dos - update selected custom panel


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Add event analytics permission toast when user doesn't have observability cluster permissions to add/get saved timestamp

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
