### PR TITLE
Panels backend call fix

### DIFF
--- a/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
+++ b/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
@@ -599,28 +599,29 @@ export const CustomPanelView = ({
               </EuiFlexItem>
             </EuiFlexGroup>
             <EuiSpacer size="l" />
-            {panelVisualizations.length === 0 && (
+            {panelVisualizations.length > 0 ? (
+              <PanelGrid
+                http={http}
+                panelId={panelId}
+                chrome={chrome}
+                panelVisualizations={panelVisualizations}
+                setPanelVisualizations={setPanelVisualizations}
+                editMode={editMode}
+                pplService={pplService}
+                startTime={start}
+                endTime={end}
+                onRefresh={onRefresh}
+                cloneVisualization={cloneVisualization}
+                pplFilterValue={pplFilterValue}
+                showFlyout={showFlyout}
+                editActionType={editActionType}
+              />
+            ) : (
               <EmptyPanelView
                 addVizDisabled={addVizDisabled}
                 getVizContextPanels={getVizContextPanels}
               />
             )}
-            <PanelGrid
-              http={http}
-              panelId={panelId}
-              chrome={chrome}
-              panelVisualizations={panelVisualizations}
-              setPanelVisualizations={setPanelVisualizations}
-              editMode={editMode}
-              pplService={pplService}
-              startTime={start}
-              endTime={end}
-              onRefresh={onRefresh}
-              cloneVisualization={cloneVisualization}
-              pplFilterValue={pplFilterValue}
-              showFlyout={showFlyout}
-              editActionType={editActionType}
-            />
           </EuiPageContentBody>
         </EuiPageBody>
       </EuiPage>

--- a/dashboards-observability/public/components/custom_panels/helpers/utils.tsx
+++ b/dashboards-observability/public/components/custom_panels/helpers/utils.tsx
@@ -326,3 +326,4 @@ export const displayVisualization = (data: any, type: string, editMode?: boolean
   }
   return vizComponent;
 };
+

--- a/dashboards-observability/public/components/custom_panels/panel_modules/panel_grid/panel_grid.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/panel_grid/panel_grid.tsx
@@ -79,12 +79,36 @@ export const PanelGrid = ({
 }: Props) => {
   const [currentLayout, setCurrentLayout] = useState<Layout[]>([]);
   const [postEditLayout, setPostEditLayout] = useState<Layout[]>([]);
+  const [gridData, setGridData] = useState(panelVisualizations.map(() => <></>));
   const isLocked = useObservable(chrome.getIsNavDrawerLocked$());
 
   // Reset Size of Visualizations when layout is changed
   const layoutChanged = (currentLayout: Layout[], allLayouts: Layouts) => {
     window.dispatchEvent(new Event('resize'));
     setPostEditLayout(currentLayout);
+  };
+
+  const loadVizComponents = () => {
+    const gridDataComps = panelVisualizations.map(
+      (panelVisualization: VisualizationType, index) => (
+        <VisualizationContainer
+          key={panelVisualization.id}
+          http={http}
+          editMode={editMode}
+          visualizationId={panelVisualization.id}
+          savedVisualizationId={panelVisualization.savedVisualizationId}
+          pplService={pplService}
+          fromTime={startTime}
+          toTime={endTime}
+          onRefresh={onRefresh}
+          cloneVisualization={cloneVisualization}
+          pplFilterValue={pplFilterValue}
+          showFlyout={showFlyout}
+          removeVisualization={removeVisualization}
+        />
+      )
+    );
+    setGridData(gridDataComps);
   };
 
   // Reload the Layout
@@ -131,6 +155,7 @@ export const PanelGrid = ({
   useEffect(() => {
     if (editMode) {
       reloadLayout();
+      loadVizComponents();
     } else {
       if (editActionType === 'save') {
         const visualizationParams = postEditLayout.map((layout) =>
@@ -144,6 +169,7 @@ export const PanelGrid = ({
   // Update layout whenever visualizations are updated
   useEffect(() => {
     reloadLayout();
+    loadVizComponents();
   }, [panelVisualizations]);
 
   // Reset Size of Panel Grid when Nav Dock is Locked
@@ -153,6 +179,10 @@ export const PanelGrid = ({
     }, 300);
   }, [isLocked]);
 
+  useEffect(() => {
+    loadVizComponents();
+  }, []);
+
   return (
     <ResponsiveGridLayout
       layouts={{ lg: currentLayout, md: currentLayout, sm: currentLayout }}
@@ -161,23 +191,8 @@ export const PanelGrid = ({
       cols={{ lg: 12, md: 12, sm: 12, xs: 1, xxs: 1 }}
       onLayoutChange={layoutChanged}
     >
-      {panelVisualizations.map((panelVisualization: VisualizationType) => (
-        <div key={panelVisualization.id}>
-          <VisualizationContainer
-            http={http}
-            editMode={editMode}
-            visualizationId={panelVisualization.id}
-            savedVisualizationId={panelVisualization.savedVisualizationId}
-            pplService={pplService}
-            fromTime={startTime}
-            toTime={endTime}
-            onRefresh={onRefresh}
-            cloneVisualization={cloneVisualization}
-            pplFilterValue={pplFilterValue}
-            showFlyout={showFlyout}
-            removeVisualization={removeVisualization}
-          />
-        </div>
+      {panelVisualizations.map((panelVisualization: VisualizationType, index) => (
+        <div key={panelVisualization.id}>{gridData[index]}</div>
       ))}
     </ResponsiveGridLayout>
   );

--- a/dashboards-observability/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
@@ -145,7 +145,7 @@ export const VisualizationContainer = ({
           <div className="visualization-error-div">
             <EuiIcon type="alert" color="danger" size="s" />
             <EuiSpacer size="s" />
-            <EuiText size='s'>
+            <EuiText size="s">
               <p>{isError}</p>
             </EuiText>
           </div>


### PR DESCRIPTION
Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>

### Description
Panel Visualizations made double backend requests to fetch data, due to re-loading in react-grid-layout.  

### Issues Resolved
1. Moved visualization loading post panel grid update

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
