### PR TITLE
Run query with shift enter

### DIFF
--- a/dashboards-observability/public/components/common/search/autocomplete.tsx
+++ b/dashboards-observability/public/components/common/search/autocomplete.tsx
@@ -358,18 +358,17 @@ export function Autocomplete({
     status: 'idle',
   });
 
-  useEffect(() => {
-    $('#autocomplete-textarea').keypress((e) => {
-      const keycode = (e.keyCode ? e.keyCode : e.which);
-      if (keycode === 13 && e.shiftKey) {
-        handleQuerySearch();
-      }
-    });
+  const searchBar = document.getElementById('autocomplete-textarea');
 
+  searchBar?.addEventListener('keydown', function (e) {
+    const keyCode = e.which || e.keyCode;
+    if (keyCode === 13 && e.shiftKey) {
+      handleQuerySearch();
+    }
     return () => {
-      $('#autocomplete-textarea').unbind('keypress');
+      $('#autocomplete-textarea').unbind('keydown');
     };
-  }, [tempQuery]);
+  })
 
   const autocomplete = useMemo(
     () => {


### PR DESCRIPTION
Signed-off-by: Eugene Lee <eugenesk@amazon.com>

### Description
Query is run when user presses shift and enter

### Issues Resolved
There had to be no suggestions for shift and enter to work

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
