### PR TITLE
Update notebooks url redirect to use plugin id

### DIFF
--- a/dashboards-observability/public/components/notebooks/components/helpers/__test__/legacy_route_helpers.test.ts
+++ b/dashboards-observability/public/components/notebooks/components/helpers/__test__/legacy_route_helpers.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { RedirectProps } from 'react-router-dom';
-import { convertLegacyNotebooksUrl } from '../helpers/legacy_route_helpers';
+import { convertLegacyNotebooksUrl } from '../legacy_route_helpers';
 
 describe('Test legacy route helpers', () => {
   it('converts legacy notebooks url', () => {

--- a/dashboards-observability/public/components/notebooks/components/helpers/legacy_route_helpers.ts
+++ b/dashboards-observability/public/components/notebooks/components/helpers/legacy_route_helpers.ts
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { observabilityID } from "../../../../../common/constants/shared";
+
 export const convertLegacyNotebooksUrl = (location: Location)=> {
-  const pathname = location.pathname.replace('notebooks-dashboards', 'observability');
+  const pathname = location.pathname.replace('notebooks-dashboards', observabilityID);
   const hash = `#/notebooks${location.hash.replace(/^#/, '')}${
     location.hash.includes('?') ? location.search.replace(/^\?/, '&') : location.search
   }`;


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Update notebooks url redirect to use plugin id

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
