### PR TITLE
Fix undefined field error and where suggestions

### DIFF
--- a/dashboards-observability/public/components/common/search/autocomplete.tsx
+++ b/dashboards-observability/public/components/common/search/autocomplete.tsx
@@ -149,13 +149,6 @@ const getSuggestions = async (str: string, dslService: DSLService) => {
       return [{ label: str + '|', input: str, suggestion: '|', itemName: '|' }].filter(
         ({ label }) => label.toLowerCase().startsWith(lowerPrefix) && lowerPrefix.localeCompare(label.toLowerCase())
       );
-    } else if (inMatch && fieldList.includes(splittedModel[splittedModel.length - 2])) {
-      inMatch = true;
-      currField = splittedModel[splittedModel.length - 2];
-      currFieldType = fieldsFromBackend.find((field) => field.label === currField)?.type;
-      return [{ label: str + ',', input: str, suggestion: ',', itemName: ','}].filter(
-        ({ suggestion }) => suggestion.startsWith(prefix) && prefix !== suggestion
-      );
     } else if (splittedModel[splittedModel.length - 2] === 'stats') {
       nextStats = splittedModel.length;
       return fillSuggestions(str, prefix, statsCommands);
@@ -215,6 +208,13 @@ const getSuggestions = async (str: string, dslService: DSLService) => {
       currField = splittedModel[splittedModel.length - 2];
       currFieldType = fieldsFromBackend.find((field: {label: string, type: string}) => field.label === currField)?.type;
       return fullSuggestions.filter((suggestion: { label: string }) => suggestion.label.toLowerCase().startsWith(lowerPrefix) && lowerPrefix.localeCompare(suggestion.label.toLowerCase()));
+    }  else if (inMatch && fieldList.includes(splittedModel[splittedModel.length - 2])) {
+      inMatch = true;
+      currField = splittedModel[splittedModel.length - 2];
+      currFieldType = fieldsFromBackend.find((field) => field.label === currField)?.type;
+      return [{ label: str + ',', input: str, suggestion: ',', itemName: ','}].filter(
+        ({ suggestion }) => suggestion.startsWith(prefix) && prefix !== suggestion
+      );
     } else if (nextWhere === splittedModel.length - 2) {
       if (isEmpty(prefix)) {
         if (!currFieldType) {

--- a/dashboards-observability/public/components/common/search/autocomplete.tsx
+++ b/dashboards-observability/public/components/common/search/autocomplete.tsx
@@ -269,7 +269,9 @@ const getFields = async (dslService: DSLService) => {
     const res = await dslService.fetchFields(currIndex);
     fieldsFromBackend.length = 0;
     for (const element in res?.[currIndex].mappings.properties) {
-      if (res?.[currIndex].mappings.properties[element].type === 'keyword') {
+      if (res?.[currIndex].mappings.properties[element].properties) {
+        fieldsFromBackend.push({ label: element, type: 'string' })
+      } else if (res?.[currIndex].mappings.properties[element].type === 'keyword') {
         fieldsFromBackend.push({ label: element, type: 'string' });
       } else {
         fieldsFromBackend.push({


### PR DESCRIPTION
### Description
1. Set type to string for fields with nested properties.
2. Correct suggestions for where command after match previously selected.

### Issues Resolved
1. Some field types were being left undefined.
2. If user selected 'match(' and then deleted and chose a field, they would not get correct suggestions.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
