### PR TITLE
Use dateFormat from advanced settings for notebook visualizations

### DIFF
--- a/dashboards-observability/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/para_output.test.tsx.snap
+++ b/dashboards-observability/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/para_output.test.tsx.snap
@@ -77,6 +77,6 @@ exports[`<ParaOutput /> spec renders visualization outputs 1`] = `
   class="euiText euiText--small"
   style="margin-left: 9px;"
 >
-  07/21/2020 06:37 PM - 08/20/2020 06:37 PM
+  2020-07-21T18:37:44+00:00 - 2020-08-20T18:37:44+00:00
 </div>
 `;

--- a/dashboards-observability/public/components/notebooks/components/paragraph_components/para_output.tsx
+++ b/dashboards-observability/public/components/notebooks/components/paragraph_components/para_output.tsx
@@ -12,8 +12,8 @@ import {
   DashboardContainerInput,
   DashboardStart,
 } from '../../../../../../../src/plugins/dashboard/public';
-import { UI_DATE_FORMAT } from '../../../../../common/constants/shared';
 import { ParaType } from '../../../../../common/types/notebooks';
+import { uiSettingsService } from '../../../../../common/utils';
 import { QueryDataGridMemo } from './para_query_grid';
 
 /*
@@ -106,8 +106,9 @@ export const ParaOutput = (props: {
             </EuiText>
           );
         case 'VISUALIZATION':
-          let from = moment(visInput?.timeRange?.from).format(UI_DATE_FORMAT);
-          let to = moment(visInput?.timeRange?.to).format(UI_DATE_FORMAT);
+          const dateFormat = uiSettingsService.get('dateFormat');
+          let from = moment(visInput?.timeRange?.from).format(dateFormat);
+          let to = moment(visInput?.timeRange?.to).format(dateFormat);
           from = from === 'Invalid date' ? visInput.timeRange.from : from;
           to = to === 'Invalid date' ? visInput.timeRange.to : to;
           return (


### PR DESCRIPTION
### Description
Use dateFormat from advanced settings for notebook visualizations

### Issues Resolved
- #250 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
