### PR TITLE
Add BWC test for Observability

### DIFF
--- a/opensearch-observability/build.gradle
+++ b/opensearch-observability/build.gradle
@@ -164,9 +164,6 @@ test {
 File repo = file("$buildDir/testclusters/repo")
 def _numNodes = findProperty('numNodes') as Integer ?: 1
 
-def es_tmp_dir = rootProject.file('build/private/es_tmp').absoluteFile
-es_tmp_dir.mkdirs()
-
 def opensearch_tmp_dir = rootProject.file('build/private/opensearch_tmp').absoluteFile
 opensearch_tmp_dir.mkdirs()
 
@@ -197,7 +194,7 @@ tasks.named("check").configure { dependsOn(integTest) }
 
 integTest {
     systemProperty 'tests.security.manager', 'false'
-    systemProperty 'java.io.tmpdir', es_tmp_dir.absolutePath
+    systemProperty 'java.io.tmpdir', opensearch_tmp_dir.absolutePath
 
     systemProperty "https", System.getProperty("https")
     systemProperty "user", System.getProperty("user")

--- a/opensearch-observability/build.gradle
+++ b/opensearch-observability/build.gradle
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import org.opensearch.gradle.test.RestIntegTestTask
 import java.util.concurrent.Callable
+import org.opensearch.gradle.test.RestIntegTestTask
+import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 buildscript {
     ext {
@@ -166,6 +167,9 @@ def _numNodes = findProperty('numNodes') as Integer ?: 1
 def es_tmp_dir = rootProject.file('build/private/es_tmp').absoluteFile
 es_tmp_dir.mkdirs()
 
+def opensearch_tmp_dir = rootProject.file('build/private/opensearch_tmp').absoluteFile
+opensearch_tmp_dir.mkdirs()
+
 // As of ES 7.7 the sample-extension-plugin is being added to the list of plugins for the testCluster during build before
 // the job-scheduler plugin (not a dependency for opensearch-observability) is causing build failures.
 // The job-scheduler zip is added explicitly above but the sample-extension-plugin is added implicitly at some time during evaluation.
@@ -223,6 +227,12 @@ integTest {
     if (System.getProperty("tests.clustername") != null) {
         exclude 'org/opensearch/observability/ObservabilityPluginIT.class'
     }
+
+    if (System.getProperty("tests.rest.bwcsuite") == null) {
+        filter {
+            excludeTestsMatching "org.opensearch.observability.bwc.*IT"
+        }
+    }
 }
 
 
@@ -245,6 +255,147 @@ testClusters.integTest {
         }
     }
     setting 'path.repo', repo.absolutePath
+}
+
+
+String bwcVersion = "1.1.0-SNAPSHOT"
+String baseName = "obsBwcCluster"
+String bwcFilePath = "src/test/kotlin/org/opensearch/observability/resources/bwc/"
+
+2.times {i ->
+    testClusters {
+        "${baseName}$i" {
+            testDistribution = "ARCHIVE"
+            versions = ["1.1.0","1.2.0-SNAPSHOT"]
+            numberOfNodes = 3
+            plugin(provider(new Callable<RegularFile>(){
+                @Override
+                RegularFile call() throws Exception {
+                    return new RegularFile() {
+                        @Override
+                        File getAsFile() {
+                            return fileTree(bwcFilePath + bwcVersion).getSingleFile()
+                        }
+                    }
+                }
+            }))
+            setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+            setting 'http.content_type.required', 'true'
+        }
+    }
+}
+
+List<Provider<RegularFile>> plugins = []
+
+// Ensure the artifact for the current project version is available to be used for the bwc tests
+task prepareBwcTests {
+    dependsOn bundle
+    doLast {
+        plugins = [
+                project.getObjects().fileProperty().value(bundle.getArchiveFile())
+        ]
+    }
+}
+
+
+// Creates 2 test clusters with 3 nodes of the old version.
+2.times {i ->
+    task "${baseName}#oldVersionClusterTask$i"(type: StandaloneRestIntegTestTask) {
+        dependsOn 'prepareBwcTests'
+        useCluster testClusters."${baseName}$i"
+        filter {
+            includeTestsMatching "org.opensearch.observability.bwc.*IT"
+        }
+        systemProperty 'tests.rest.bwcsuite', 'old_cluster'
+        systemProperty 'tests.rest.bwcsuite_round', 'old'
+        systemProperty 'tests.plugin_bwc_version', bwcVersion
+        nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}$i".allHttpSocketURI.join(",")}")
+        nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}$i".getName()}")
+    }
+}
+
+// Upgrades one node of the old cluster to new OpenSearch version with upgraded plugin version
+// This results in a mixed cluster with 2 nodes on the old version and 1 upgraded node.
+// This is also used as a one third upgraded cluster for a rolling upgrade.
+task "${baseName}#mixedClusterTask"(type: StandaloneRestIntegTestTask) {
+    useCluster testClusters."${baseName}0"
+    dependsOn "${baseName}#oldVersionClusterTask0"
+    doFirst {
+        testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
+    }
+    filter {
+        includeTestsMatching "org.opensearch.observability.bwc.*IT"
+    }
+    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
+    systemProperty 'tests.rest.bwcsuite_round', 'first'
+    systemProperty 'tests.plugin_bwc_version', bwcVersion
+    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
+}
+
+// Upgrades the second node to new OpenSearch version with upgraded plugin version after the first node is upgraded.
+// This results in a mixed cluster with 1 node on the old version and 2 upgraded nodes.
+// This is used for rolling upgrade.
+task "${baseName}#twoThirdsUpgradedClusterTask"(type: StandaloneRestIntegTestTask) {
+    dependsOn "${baseName}#mixedClusterTask"
+    useCluster testClusters."${baseName}0"
+    doFirst {
+        testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
+    }
+    filter {
+        includeTestsMatching "org.opensearch.observability.bwc.*IT"
+    }
+    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
+    systemProperty 'tests.rest.bwcsuite_round', 'second'
+    systemProperty 'tests.plugin_bwc_version', bwcVersion
+    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
+}
+
+// Upgrades the third node to new OpenSearch version with upgraded plugin version after the second node is upgraded.
+// This results in a fully upgraded cluster.
+// This is used for rolling upgrade.
+task "${baseName}#rollingUpgradeClusterTask"(type: StandaloneRestIntegTestTask) {
+    dependsOn "${baseName}#twoThirdsUpgradedClusterTask"
+    useCluster testClusters."${baseName}0"
+    doFirst {
+        testClusters."${baseName}0".upgradeNodeAndPluginToNextVersion(plugins)
+    }
+    filter {
+        includeTestsMatching "org.opensearch.observability.bwc.*IT"
+    }
+    mustRunAfter "${baseName}#mixedClusterTask"
+    systemProperty 'tests.rest.bwcsuite', 'mixed_cluster'
+    systemProperty 'tests.rest.bwcsuite_round', 'third'
+    systemProperty 'tests.plugin_bwc_version', bwcVersion
+    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}0".allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}0".getName()}")
+}
+
+// Upgrades all the nodes of the old cluster to new OpenSearch version with upgraded plugin version
+// at the same time resulting in a fully upgraded cluster.
+task "${baseName}#fullRestartClusterTask"(type: StandaloneRestIntegTestTask) {
+    dependsOn "${baseName}#oldVersionClusterTask1"
+    useCluster testClusters."${baseName}1"
+    doFirst {
+        testClusters."${baseName}1".upgradeAllNodesAndPluginsToNextVersion(plugins)
+    }
+    filter {
+        includeTestsMatching "org.opensearch.observability.bwc.*IT"
+    }
+    systemProperty 'tests.rest.bwcsuite', 'upgraded_cluster'
+    systemProperty 'tests.plugin_bwc_version', bwcVersion
+    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}1".allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}1".getName()}")
+}
+
+// A bwc test suite which runs all the bwc tasks combined.
+task bwcTestSuite(type: StandaloneRestIntegTestTask) {
+    exclude '**/*Test*'
+    exclude '**/*IT*'
+    dependsOn tasks.named("${baseName}#mixedClusterTask")
+    dependsOn tasks.named("${baseName}#rollingUpgradeClusterTask")
+    dependsOn tasks.named("${baseName}#fullRestartClusterTask")
 }
 
 run {

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/ObservabilityPlugin.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/ObservabilityPlugin.kt
@@ -46,6 +46,7 @@ class ObservabilityPlugin : Plugin(), ActionPlugin {
         const val PLUGIN_NAME = "opensearch-observability"
         const val LOG_PREFIX = "observability"
         const val BASE_OBSERVABILITY_URI = "/_plugins/_observability"
+        const val BASE_NOTEBOOKS_URI = "/_plugins/_notebooks"
     }
 
     /**

--- a/opensearch-observability/src/test/kotlin/org/opensearch/observability/PluginRestTestCase.kt
+++ b/opensearch-observability/src/test/kotlin/org/opensearch/observability/PluginRestTestCase.kt
@@ -63,9 +63,12 @@ abstract class PluginRestTestCase : OpenSearchRestTestCase() {
         return true
     }
 
+    open fun preserveOpenSearchIndicesAfterTest(): Boolean = false
+
     @Throws(IOException::class)
     @After
     open fun wipeAllOpenSearchIndices() {
+        if (preserveOpenSearchIndicesAfterTest()) return
         val response = client().performRequest(Request("GET", "/_cat/indices?format=json&expand_wildcards=all"))
         val xContentType = XContentType.fromMediaTypeOrFormat(response.entity.contentType.value)
         xContentType.xContent().createParser(

--- a/opensearch-observability/src/test/kotlin/org/opensearch/observability/bwc/TABackwardCompatibilityIT.kt
+++ b/opensearch-observability/src/test/kotlin/org/opensearch/observability/bwc/TABackwardCompatibilityIT.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.observability.bwc
+
+import org.junit.Assert
+import org.opensearch.common.settings.Settings
+import org.opensearch.observability.ObservabilityPlugin.Companion.BASE_NOTEBOOKS_URI
+import org.opensearch.observability.ObservabilityPlugin.Companion.BASE_OBSERVABILITY_URI
+import org.opensearch.observability.PluginRestTestCase
+import org.opensearch.observability.constructNotebookRequest
+import org.opensearch.rest.RestRequest
+import org.opensearch.rest.RestStatus
+import java.util.List
+import java.util.Map
+
+class TABackwardCompatibilityIT : PluginRestTestCase() {
+
+    companion object {
+        private val CLUSTER_TYPE: ClusterType = ClusterType.parse(System.getProperty("tests.rest.bwcsuite"))
+        private val CLUSTER_NAME: String = System.getProperty("tests.clustername")
+    }
+
+    override fun preserveReposUponCompletion(): Boolean = true
+
+    override fun preserveIndicesUponCompletion(): Boolean = true
+
+    override fun preserveTemplatesUponCompletion(): Boolean = true
+
+    override fun preserveOpenSearchIndicesAfterTest(): Boolean = true
+
+    override fun restClientSettings(): Settings {
+        return Settings.builder()
+            .put(super.restClientSettings())
+            // increase the timeout here to 90 seconds to handle long waits for a green
+            // cluster health. the waits for green need to be longer than a minute to
+            // account for delayed shards
+            .put(CLIENT_SOCKET_TIMEOUT, "90s")
+            .build()
+    }
+
+    private enum class ClusterType {
+        OLD,
+        MIXED,
+        UPGRADED;
+
+        companion object {
+            fun parse(value: String): ClusterType {
+                return when (value) {
+                    "old_cluster" -> OLD
+                    "mixed_cluster" -> MIXED
+                    "upgraded_cluster" -> UPGRADED
+                    else -> {
+                        throw AssertionError("unknown cluster type: $value")
+                    }
+                }
+            }
+        }
+    }
+
+    @Throws(Exception::class)
+    @SuppressWarnings("unchecked")
+    fun `test backwards compatibility`() {
+        val uri = getUri()
+        val responseMap = getAsMap(uri)["nodes"] as Map<String, Map<String, Any>>
+        for (response in responseMap.values()) {
+            val plugins = response["plugins"] as List<Map<String, Any>>
+            val pluginNames = plugins.map { plugin -> plugin["name"] }.toSet()
+            return when (CLUSTER_TYPE) {
+                ClusterType.OLD -> {
+                    assertTrue(pluginNames.contains("opensearch-notebooks"))
+                    createNotebook()
+                }
+                ClusterType.MIXED -> {
+                    assertTrue(pluginNames.contains("opensearch-observability"))
+                    if (System.getProperty("tests.rest.bwcsuite_round") != "third") {
+                        verifyNotebooksExists("$BASE_NOTEBOOKS_URI/notebooks")
+                    } else verifyNotebooksExists("$BASE_OBSERVABILITY_URI/object")
+                }
+                ClusterType.UPGRADED -> {
+                    assertTrue(pluginNames.contains("opensearch-observability"))
+                    verifyNotebooksExists("$BASE_OBSERVABILITY_URI/object")
+                }
+            }
+            break
+        }
+    }
+
+    private fun getUri(): String {
+        return when (CLUSTER_TYPE) {
+            ClusterType.OLD -> "_nodes/" + CLUSTER_NAME + "-0/plugins"
+            ClusterType.MIXED -> {
+                when (System.getProperty("tests.rest.bwcsuite_round")) {
+                    "second" -> "_nodes/$CLUSTER_NAME-1/plugins"
+                    "third" -> "_nodes/$CLUSTER_NAME-2/plugins"
+                    else -> "_nodes/$CLUSTER_NAME-0/plugins"
+                }
+            }
+            ClusterType.UPGRADED -> "_nodes/plugins"
+        }
+    }
+
+    private fun createNotebook() {
+        val createRequest = constructNotebookRequest()
+        val createResponse = executeRequest(
+            RestRequest.Method.POST.name,
+            "$BASE_NOTEBOOKS_URI/notebook",
+            createRequest,
+            RestStatus.OK.status
+        )
+        val id = createResponse.get("notebookId").asString
+        Assert.assertNotNull("Id should be generated", id)
+        Thread.sleep(100)
+    }
+
+    private fun verifyNotebooksExists(uri: String) {
+        val listNotebooks = executeRequest(
+            RestRequest.Method.GET.name,
+            "$uri",
+            "",
+            RestStatus.OK.status
+        )
+        val totalHits = listNotebooks.get("totalHits").asInt
+        assertTrue("Actual notebooks counts ($totalHits) should be greater than or equal to (1)", totalHits >= 1)
+    }
+}

--- a/opensearch-observability/src/test/kotlin/org/opensearch/observability/bwc/TABackwardCompatibilityIT.kt
+++ b/opensearch-observability/src/test/kotlin/org/opensearch/observability/bwc/TABackwardCompatibilityIT.kt
@@ -123,6 +123,6 @@ class TABackwardCompatibilityIT : PluginRestTestCase() {
             RestStatus.OK.status
         )
         val totalHits = listNotebooks.get("totalHits").asInt
-        assertTrue("Actual notebooks counts ($totalHits) should be greater than or equal to (1)", totalHits >= 1)
+        assertTrue("Actual notebooks counts ($totalHits) should be equal to (1)", totalHits == 1)
     }
 }


### PR DESCRIPTION
Signed-off-by: Kavitha Conjeevaram Mohan <mohakavi@amazon.com>

### Description

- Add bwc specific Integration Test
- Update gradle.build to run bwc tests from opensearch 1.1 to opensearch 1.2
- Included snapshot of Notebooks 1.1 and Observability 1.2

### Issues Resolved
#276 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
