### PR TITLE
Update tests, builds and doc

### DIFF
--- a/.github/workflows/opensearch-observability-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-observability-test-and-build-workflow.yml
@@ -3,7 +3,7 @@ name: Test and Build OpenSearch Observability Backend Plugin
 on: [pull_request, push]
 
 env:
-  OPENSEARCH_VERSION: '1.2.0-SNAPSHOT'
+  OPENSEARCH_VERSION: '1.2.1-SNAPSHOT'
   OPENSEARCH_BRANCH: '1.2'
   COMMON_UTILS_BRANCH: 'main'
 

--- a/opensearch-observability/build.gradle
+++ b/opensearch-observability/build.gradle
@@ -9,7 +9,7 @@ import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.2.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.2.1-SNAPSHOT")
         // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
         opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
@@ -262,7 +262,7 @@ String bwcFilePath = "src/test/kotlin/org/opensearch/observability/resources/bwc
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["1.1.0","1.2.0-SNAPSHOT"]
+            versions = ["1.1.0","1.2.1-SNAPSHOT"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>(){
                 @Override

--- a/opensearch-observability/build.gradle
+++ b/opensearch-observability/build.gradle
@@ -254,7 +254,6 @@ testClusters.integTest {
     setting 'path.repo', repo.absolutePath
 }
 
-
 String bwcVersion = "1.1.0-SNAPSHOT"
 String baseName = "obsBwcCluster"
 String bwcFilePath = "src/test/kotlin/org/opensearch/observability/resources/bwc/"
@@ -393,6 +392,24 @@ task bwcTestSuite(type: StandaloneRestIntegTestTask) {
     dependsOn tasks.named("${baseName}#mixedClusterTask")
     dependsOn tasks.named("${baseName}#rollingUpgradeClusterTask")
     dependsOn tasks.named("${baseName}#fullRestartClusterTask")
+}
+
+task integTestRemote(type: RestIntegTestTask) {
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'tests.security.manager', 'false'
+    systemProperty 'java.io.tmpdir', opensearch_tmp_dir.absolutePath
+
+    systemProperty "https", System.getProperty("https")
+    systemProperty "user", System.getProperty("user")
+    systemProperty "password", System.getProperty("password")
+
+    // Only rest case can run with remote cluster
+    if (System.getProperty("tests.rest.cluster") != null) {
+        filter {
+            includeTestsMatching "org.opensearch.observability.rest.*IT"
+        }
+    }
 }
 
 run {

--- a/release-notes/opensearch-trace-analytics.release-notes-1.2.1.0.md
+++ b/release-notes/opensearch-trace-analytics.release-notes-1.2.1.0.md
@@ -1,0 +1,6 @@
+## Version 1.2.1.0 Release Notes
+
+Compatible with OpenSearch Version 1.2.1 and OpenSearch Dashboards Version 1.2.0
+
+### Maintenance
+* Bump observability version for OpenSearch 1.2.1 release ([#313](https://github.com/opensearch-project/trace-analytics/pull/313))


### PR DESCRIPTION
### Description
Upgraded build files and bump to 1.2.1, added remote integ test

### Issues Resolved
1. Upgraded failing bwc tests
2. Version bump and release doc
3. Added remote integration tests #223 

Command to test without security
```
./gradlew integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="dokcer-cluster"
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
