### PR TITLE
Fix deprecated GitHub upload artifact action version

### DIFF
--- a/.github/workflows/opensearch-observability-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-observability-test-and-build-workflow.yml
@@ -58,7 +58,7 @@ jobs:
           cp -r ./build/distributions/*.zip opensearch-observability-builds/
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3-node20
         with:
           name: opensearch-observability-ubuntu-latest
           path: opensearch-observability-builds
@@ -79,7 +79,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-    
+
       - name: Build with Gradle
         run: |
           ./gradlew build

--- a/.github/workflows/opensearch-observability-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-observability-test-and-build-workflow.yml
@@ -90,7 +90,7 @@ jobs:
           cp -r ./build/distributions/*.zip opensearch-observability-builds/
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3-node20
         with:
           name: opensearch-observability-${{ matrix.os }}
           path: opensearch-observability-builds

--- a/.github/workflows/opensearch-observability-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-observability-test-and-build-workflow.yml
@@ -20,20 +20,23 @@ jobs:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
       # this image tag is subject to change as more dependencies and updates will arrive over time
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
-      # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
 
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
-      - uses: actions/checkout@v1
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
 
+      - uses: actions/checkout@v4
+        
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-    
+          distribution: 'temurin'
+      
       - name: Run Backwards Compatibility Tests
         run: |
           echo "Running backwards compatibility tests ..."
@@ -73,11 +76,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
       - name: Build with Gradle

--- a/release-notes/opensearch-observability.release-notes-2.11.0.0.md
+++ b/release-notes/opensearch-observability.release-notes-2.11.0.0.md
@@ -1,0 +1,10 @@
+## Version 2.11.0.0 Release Notes
+
+Compatible with OpenSearch 2.11.0
+
+### Maintenance
+- Updates demo certs used in integ tests ([#1626](https://github.com/opensearch-project/observability/pull/1626))
+
+---
+
+Full Changelog: https://github.com/opensearch-project/observability/compare/2.11...2.3


### PR DESCRIPTION
### Description
fix deprecated  version of `actions/upload-artifact: v1`
see https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

To introduce additional start command for all CI build which rely on the OpnSearch Docker image, as Github rollout the deprecation of the Node 16 on all it's CI-runner, as the result all existing Github which rely on the old version of Node.JS (Ex: actions/checkout@v3) failed due to the following errors:

```
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
```
<img width="728" alt="image" src="https://github.com/user-attachments/assets/3795abc8-35c6-44a0-b9fd-2730ff8db0ac">

The issue has been discovered over https://github.com/opensearch-project/opensearch-build/issues/5178 and fix has been verified and  applied on multiple OpenSearch plugin, such as: 
 - https://github.com/opensearch-project/ml-commons/pull/3223
 - https://github.com/opensearch-project/asynchronous-search/pull/676


### Related Issues
Partially resolves: https://github.com/opensearch-project/sql/issues/3168

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/observability/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
