### PR TITLE
Replace java.security.AccessController with OpenSearch replacement

### DIFF
--- a/src/main/kotlin/org/opensearch/observability/security/SecurityAccess.kt
+++ b/src/main/kotlin/org/opensearch/observability/security/SecurityAccess.kt
@@ -5,10 +5,8 @@
 
 package org.opensearch.observability.security
 
-import org.opensearch.SpecialPermission
-import java.security.AccessController
-import java.security.PrivilegedActionException
-import java.security.PrivilegedExceptionAction
+import org.opensearch.secure_sm.AccessController
+import java.util.function.Supplier
 
 /**
  * Class for providing the elevated permission for the function call.
@@ -20,12 +18,7 @@ internal object SecurityAccess {
      * Execute the operation in privileged mode.
      */
     @Throws(Exception::class)
-    fun <T> doPrivileged(operation: PrivilegedExceptionAction<T>?): T {
-        SpecialPermission.check()
-        return try {
-            AccessController.doPrivileged(operation)
-        } catch (@Suppress("SwallowedException") e: PrivilegedActionException) {
-            throw (e.cause as Exception?)!!
-        }
+    fun <T> doPrivileged(operation: Supplier<T>): T {
+        return AccessController.doPrivileged(operation)
     }
 }


### PR DESCRIPTION
### Description

Replace java.security.AccessController with OpenSearch replacement

### Related Issues

Related to https://github.com/opensearch-project/OpenSearch/issues/18339

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/observability/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
