### PR TITLE
decouple jackson annotation version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,7 @@ dependencies {
     // see https://github.com/opensearch-project/OpenSearch/issues/5395.
     implementation group: 'com.github.wnameless.json', name: 'json-base', version: '2.2.1'
     implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
     testImplementation(
             'org.assertj:assertj-core:3.16.1',
             'org.junit.jupiter:junit-jupiter-api:5.6.2'


### PR DESCRIPTION
### Description

Using `${versions.jackson_annotations}` instead of `${versions.jackson}` to leverage the separate versioning that the upstream OpenSearch build tools introduced in PR https://github.com/opensearch-project/OpenSearch/pull/20343/. This properly handles the fact that jackson-annotations 2.20 is available in Maven Central, while the other Jackson artifacts use 2.20.1.

### Related Issues
Resolves https://github.com/opensearch-project/observability/issues/1967


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/observability/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
