### PR TITLE
Fix CI checks by downloading plugin snapshots for testing from ci.opensearch.org

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -349,16 +349,36 @@ testClusters.integTest {
     setting 'path.repo', repo.absolutePath
 }
 
-String baseVersion = "2.20.0"
+String baseVersion = "2.19.4"
 String bwcVersion = baseVersion + ".0"
 String baseName = "obsBwcCluster"
 String bwcFilePath = "src/test/resources/bwc/"
-String bwcObservabilityPlugin = "opensearch-observability-" + bwcVersion + ".zip"
-// TODO: remove bwc job scheduler after 2.9 release
-String bwcJobSchedulerPlugin = "opensearch-job-scheduler-" + bwcVersion + ".zip"
-String remoteFileURL = "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-observability&v=$bwcVersion-SNAPSHOT&p=zip"
-String bwcJobSchedulerURL = "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=$bwcVersion-SNAPSHOT&p=zip"
 String bwcSnapshotVersion = baseVersion + "-SNAPSHOT"
+String bwcPluginSnapshotVersion = bwcVersion + "-SNAPSHOT"
+String groupPath = "org/opensearch/plugin"
+String base = "https://ci.opensearch.org/ci/dbc/snapshots/maven"
+
+def resolveZipSnapshotValue = { String metadataXmlUrl ->
+    def xml = new URL(metadataXmlUrl).text
+    def m = (xml =~ /<snapshotVersion>[\s\S]*?<extension>zip<\/extension>[\s\S]*?<value>([^<]+)<\/value>[\s\S]*?<\/snapshotVersion>/)
+    if (!m.find()) {
+        throw new GradleException("Could not find zip snapshot <value> in ${metadataXmlUrl}")
+    }
+    return m.group(1)
+}
+
+String observabilityArtifact = "opensearch-observability"
+String observabilityMetadataUrl = "${base}/${groupPath}/${observabilityArtifact}/${bwcPluginSnapshotVersion}/maven-metadata.xml"
+String observabilitySnapshotValue = resolveZipSnapshotValue(observabilityMetadataUrl)
+String bwcObservabilityPlugin = "${observabilityArtifact}-${observabilitySnapshotValue}.zip"
+String remoteFileURL = "${base}/${groupPath}/${observabilityArtifact}/${bwcPluginSnapshotVersion}/${bwcObservabilityPlugin}"
+
+// TODO: remove bwc job scheduler after 2.9 release
+String jobSchedulerArtifact = "opensearch-job-scheduler"
+String jobSchedulerMetadataUrl = "${base}/${groupPath}/${jobSchedulerArtifact}/${bwcPluginSnapshotVersion}/maven-metadata.xml"
+String jobSchedulerSnapshotValue = resolveZipSnapshotValue(jobSchedulerMetadataUrl)
+String bwcJobSchedulerPlugin = "${jobSchedulerArtifact}-${jobSchedulerSnapshotValue}.zip"
+String bwcJobSchedulerURL = "${base}/${groupPath}/${jobSchedulerArtifact}/${bwcPluginSnapshotVersion}/${bwcJobSchedulerPlugin}"
 
 2.times {i ->
     testClusters {


### PR DESCRIPTION
### Description

Fix CI checks by downloading plugin snapshots for testing from ci.opensearch.org

Similar to changes in https://github.com/opensearch-project/job-scheduler/pull/877

### Related Issues

Fixes CI failures seen in https://github.com/opensearch-project/observability/pull/1971

```
* What went wrong:
Could not determine the dependencies of task ':obsBwcCluster#fullRestartClusterTask'.
> Server returned HTTP response code: 402 for URL: https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-observability&v=2.20.0.0-SNAPSHOT&p=zip
```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/observability/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
