### PR TITLE
Replace java.security.AccessController with org.opensearch.secure_sm.AccessController

### DIFF
--- a/src/main/kotlin/org/opensearch/observability/security/SecurityAccess.kt
+++ b/src/main/kotlin/org/opensearch/observability/security/SecurityAccess.kt
@@ -15,7 +15,5 @@ internal object SecurityAccess {
      * Execute the operation in privileged mode.
      */
     @Throws(Exception::class)
-    fun <T> doPrivileged(operation: AccessController.CheckedSupplier<T, Exception>): T {
-        return AccessController.doPrivilegedChecked(operation)
-    }
+    fun <T> doPrivileged(operation: AccessController.CheckedSupplier<T, Exception>): T = AccessController.doPrivilegedChecked(operation)
 }


### PR DESCRIPTION
### Description

Replace java.security.AccessController with org.opensearch.secure_sm.AccessController.

java.security.AccessController is marked for removal and needs to be replaced.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/observability/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
