### PR TITLE
Increment version to 3.8.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ import io.gitlab.arturbosch.detekt.Detekt
 buildscript {
     ext {
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "3.7.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.8.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'


### PR DESCRIPTION
## Summary
- Bumps the default `opensearch.version` in `build.gradle` from `3.7.0-SNAPSHOT` to `3.8.0-SNAPSHOT` to align with the OpenSearch / OpenSearch-Dashboards 3.8.0 version bump.

Follows the same pattern as #1982.

## Test plan
- [ ] CI builds pass against `3.8.0-SNAPSHOT`

Signed-off-by: Adam Tackett <tackadam@amazon.com>