### PR TITLE
[CVE][2.19] Bump assertj-core to 3.27.7 (CVE-2026-24400)

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -7,7 +7,7 @@ jobs:
   enforce-label:
     runs-on: ubuntu-latest
     steps:
-    - uses: yogevbd/enforce-label-action@2.1.0
+    - uses: yogevbd/enforce-label-action@8d1e1709b1011e6d90400a0e6cf7c0b77aa5efeb # 2.1.0
       with:
         REQUIRED_LABELS_ANY: "breaking,feature,enhancement,bug,infrastructure,dependencies,documentation,maintenance,skip-changelog"
         REQUIRED_LABELS_ANY_DESCRIPTION: "A release label is required: ['breaking', 'bug', 'dependencies', 'documentation', 'enhancement', 'feature', 'infrastructure', 'maintenance', 'skip-changelog']"

--- a/.github/workflows/opensearch-observability-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-observability-test-and-build-workflow.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Run start commands
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -45,7 +45,7 @@ jobs:
           su `id -un 1000` -c "./gradlew build"
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # v1
         with:
           flags: opensearch-observability
           directory: opensearch-observability/
@@ -57,7 +57,7 @@ jobs:
           cp -r ./build/distributions/*.zip opensearch-observability-builds/
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: opensearch-observability-${{ matrix.os }}-${{ matrix.java }}
           path: opensearch-observability-builds
@@ -72,10 +72,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -90,7 +90,7 @@ jobs:
           cp -r ./build/distributions/*.zip opensearch-observability-builds/
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: opensearch-observability-${{ matrix.os }}-${{ matrix.java }}
           path: opensearch-observability-builds

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,16 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-allopen:${kotlin_version}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.4"
         classpath "org.jacoco:org.jacoco.agent:0.8.11"
+        // The opensearch.pluginzip plugin (validatePluginZipPom) otherwise pulls a
+        // newer plexus-utils compiled for Java 17 (class file v61), which breaks the
+        // Java 11 build legs. Pin to the last Java 11-compatible release.
+        classpath "org.codehaus.plexus:plexus-utils:3.5.1"
+    }
+
+    configurations.classpath {
+        resolutionStrategy {
+            force "org.codehaus.plexus:plexus-utils:3.5.1"
+        }
     }
 }
 
@@ -159,6 +169,9 @@ configurations.all {
         force "org.slf4j:slf4j-api:2.0.0"
         force "ch.qos.logback:logback-classic:1.5.20"
         force "ch.qos.logback:logback-core:1.5.20"
+        // plexus-utils 4.x is compiled for Java 17; pin to the last Java 11
+        // compatible release so the Java 11 build legs can load it.
+        force "org.codehaus.plexus:plexus-utils:3.5.1"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jackson_version}"
     testImplementation(
-            'org.assertj:assertj-core:3.16.1',
+            'org.assertj:assertj-core:3.27.7',
             'org.junit.jupiter:junit-jupiter-api:5.6.2'
     )
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')


### PR DESCRIPTION
### Description
Remediates **CVE-2026-24400** (GHSA-rqfh-9r24-8c9r): AssertJ before 3.27.7 has an XML External Entity (XXE) vulnerability in the `isXmlEqualTo` assertion when parsing untrusted XML. Bumps the test dependency `org.assertj:assertj-core` from `3.16.1` to `3.27.7`.

`assertj-core` is a `testImplementation` dependency (test-scope only). The `main` branch is already on `3.27.7`; this brings `2.19` in line.

| CVE | Package | Was | Now |
|---|---|---|---|
| CVE-2026-24400 | org.assertj:assertj-core | 3.16.1 | 3.27.7 |

### Issues Resolved
CVE-2026-24400

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.