### PR TITLE
docs: remove unsupported inheritDoc KDoc

### DIFF
--- a/src/main/kotlin/org/opensearch/observability/ObservabilityPlugin.kt
+++ b/src/main/kotlin/org/opensearch/observability/ObservabilityPlugin.kt
@@ -54,23 +54,14 @@ class ObservabilityPlugin :
         const val BASE_NOTEBOOKS_URI = "/_plugins/_notebooks"
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun getSettings(): List<Setting<*>> = PluginSettings.getAllSettings()
 
-    /**
-     * {@inheritDoc}
-     */
     override fun getSystemIndexDescriptors(settings: Settings): Collection<SystemIndexDescriptor> =
         listOf(
             SystemIndexDescriptor(ObservabilityIndex.INDEX_NAME, "Observability Plugin Configuration index"),
             SystemIndexDescriptor(ObservabilityIndex.NOTEBOOKS_INDEX_NAME, "Observability Plugin Notebooks index"),
         )
 
-    /**
-     * {@inheritDoc}
-     */
     override fun createComponents(
         client: Client,
         clusterService: ClusterService,
@@ -89,9 +80,6 @@ class ObservabilityPlugin :
         return emptyList()
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun getRestHandlers(
         settings: Settings,
         restController: RestController,
@@ -106,9 +94,6 @@ class ObservabilityPlugin :
             ObservabilityStatsRestHandler(),
         )
 
-    /**
-     * {@inheritDoc}
-     */
     override fun getActions(): List<ActionPlugin.ActionHandler<out ActionRequest, out ActionResponse>> =
         listOf(
             ActionPlugin.ActionHandler(

--- a/src/main/kotlin/org/opensearch/observability/action/CreateObservabilityObjectAction.kt
+++ b/src/main/kotlin/org/opensearch/observability/action/CreateObservabilityObjectAction.kt
@@ -35,9 +35,6 @@ internal class CreateObservabilityObjectAction
             internal val ACTION_TYPE = ActionType(NAME, ::CreateObservabilityObjectResponse)
         }
 
-        /**
-         * {@inheritDoc}
-         */
         override fun executeRequest(
             request: CreateObservabilityObjectRequest,
             user: User?,

--- a/src/main/kotlin/org/opensearch/observability/action/CreateObservabilityObjectRequest.kt
+++ b/src/main/kotlin/org/opensearch/observability/action/CreateObservabilityObjectRequest.kt
@@ -87,9 +87,6 @@ internal class CreateObservabilityObjectRequest :
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun toXContent(
         builder: XContentBuilder?,
         params: ToXContent.Params?,
@@ -114,9 +111,6 @@ internal class CreateObservabilityObjectRequest :
         this.objectData = objectData
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Throws(IOException::class)
     constructor(input: StreamInput) : super(input) {
         objectId = input.readOptionalString()
@@ -131,9 +125,6 @@ internal class CreateObservabilityObjectRequest :
             )
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Throws(IOException::class)
     override fun writeTo(output: StreamOutput) {
         super.writeTo(output)
@@ -143,8 +134,5 @@ internal class CreateObservabilityObjectRequest :
         output.writeOptionalWriteable(objectData)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun validate(): ActionRequestValidationException? = null
 }

--- a/src/main/kotlin/org/opensearch/observability/action/CreateObservabilityObjectResponse.kt
+++ b/src/main/kotlin/org/opensearch/observability/action/CreateObservabilityObjectResponse.kt
@@ -72,25 +72,16 @@ internal class CreateObservabilityObjectResponse : BaseResponse {
         this.objectId = id
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Throws(IOException::class)
     constructor(input: StreamInput) : super(input) {
         objectId = input.readString()
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Throws(IOException::class)
     override fun writeTo(output: StreamOutput) {
         output.writeString(objectId)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun toXContent(
         builder: XContentBuilder?,
         params: ToXContent.Params?,

--- a/src/main/kotlin/org/opensearch/observability/action/DeleteObservabilityObjectAction.kt
+++ b/src/main/kotlin/org/opensearch/observability/action/DeleteObservabilityObjectAction.kt
@@ -35,9 +35,6 @@ internal class DeleteObservabilityObjectAction
             internal val ACTION_TYPE = ActionType(NAME, ::DeleteObservabilityObjectResponse)
         }
 
-        /**
-         * {@inheritDoc}
-         */
         override fun executeRequest(
             request: DeleteObservabilityObjectRequest,
             user: User?,

--- a/src/main/kotlin/org/opensearch/observability/action/DeleteObservabilityObjectRequest.kt
+++ b/src/main/kotlin/org/opensearch/observability/action/DeleteObservabilityObjectRequest.kt
@@ -81,26 +81,17 @@ internal class DeleteObservabilityObjectRequest :
         this.objectIds = objectIds
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Throws(IOException::class)
     constructor(input: StreamInput) : super(input) {
         objectIds = input.readStringList().toSet()
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Throws(IOException::class)
     override fun writeTo(output: StreamOutput) {
         super.writeTo(output)
         output.writeStringCollection(objectIds)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun toXContent(
         builder: XContentBuilder?,
         params: ToXContent.Params?,
@@ -112,9 +103,6 @@ internal class DeleteObservabilityObjectRequest :
             .endObject()
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun validate(): ActionRequestValidationException? {
         var validationException: ActionRequestValidationException? = null
         if (objectIds.isNullOrEmpty()) {

--- a/src/main/kotlin/org/opensearch/observability/action/DeleteObservabilityObjectResponse.kt
+++ b/src/main/kotlin/org/opensearch/observability/action/DeleteObservabilityObjectResponse.kt
@@ -79,25 +79,16 @@ internal class DeleteObservabilityObjectResponse : BaseResponse {
         this.objectIdToStatus = objectIdToStatus
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Throws(IOException::class)
     constructor(input: StreamInput) : super(input) {
         objectIdToStatus = input.readMap(STRING_READER, enumReader(RestStatus::class.java))
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Throws(IOException::class)
     override fun writeTo(output: StreamOutput) {
         output.writeMap(objectIdToStatus, STRING_WRITER, enumWriter(RestStatus::class.java))
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun toXContent(
         builder: XContentBuilder?,
         params: ToXContent.Params?,

--- a/src/main/kotlin/org/opensearch/observability/action/GetObservabilityObjectAction.kt
+++ b/src/main/kotlin/org/opensearch/observability/action/GetObservabilityObjectAction.kt
@@ -35,9 +35,6 @@ internal class GetObservabilityObjectAction
             internal val ACTION_TYPE = ActionType(NAME, ::GetObservabilityObjectResponse)
         }
 
-        /**
-         * {@inheritDoc}
-         */
         override fun executeRequest(
             request: GetObservabilityObjectRequest,
             user: User?,

--- a/src/main/kotlin/org/opensearch/observability/action/GetObservabilityObjectRequest.kt
+++ b/src/main/kotlin/org/opensearch/observability/action/GetObservabilityObjectRequest.kt
@@ -128,9 +128,6 @@ class GetObservabilityObjectRequest :
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun toXContent(
         builder: XContentBuilder?,
         params: ToXContent.Params?,
@@ -174,9 +171,6 @@ class GetObservabilityObjectRequest :
         this.filterParams = filterParams
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Throws(IOException::class)
     constructor(input: StreamInput) : super(input) {
         objectIds = input.readStringList().toSet()
@@ -188,9 +182,6 @@ class GetObservabilityObjectRequest :
         filterParams = input.readMap(STRING_READER, STRING_READER)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Throws(IOException::class)
     override fun writeTo(output: StreamOutput) {
         super.writeTo(output)
@@ -203,9 +194,6 @@ class GetObservabilityObjectRequest :
         output.writeMap(filterParams, STRING_WRITER, STRING_WRITER)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun validate(): ActionRequestValidationException? {
         var validationException: ActionRequestValidationException? = null
         if (fromIndex < 0) {

--- a/src/main/kotlin/org/opensearch/observability/action/GetObservabilityObjectResponse.kt
+++ b/src/main/kotlin/org/opensearch/observability/action/GetObservabilityObjectResponse.kt
@@ -51,27 +51,18 @@ internal class GetObservabilityObjectResponse : BaseResponse {
         this.filterSensitiveInfo = filterSensitiveInfo
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Throws(IOException::class)
     constructor(input: StreamInput) : super(input) {
         searchResult = ObservabilityObjectSearchResult(input)
         filterSensitiveInfo = input.readBoolean()
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Throws(IOException::class)
     override fun writeTo(output: StreamOutput) {
         searchResult.writeTo(output)
         output.writeBoolean(filterSensitiveInfo)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun toXContent(
         builder: XContentBuilder?,
         params: ToXContent.Params?,

--- a/src/main/kotlin/org/opensearch/observability/action/PluginBaseAction.kt
+++ b/src/main/kotlin/org/opensearch/observability/action/PluginBaseAction.kt
@@ -43,9 +43,6 @@ abstract class PluginBaseAction<Request : ActionRequest, Response : ActionRespon
         private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Suppress("TooGenericExceptionCaught")
     override fun doExecute(
         task: Task?,

--- a/src/main/kotlin/org/opensearch/observability/action/UpdateObservabilityObjectAction.kt
+++ b/src/main/kotlin/org/opensearch/observability/action/UpdateObservabilityObjectAction.kt
@@ -35,9 +35,6 @@ internal class UpdateObservabilityObjectAction
             internal val ACTION_TYPE = ActionType(NAME, ::UpdateObservabilityObjectResponse)
         }
 
-        /**
-         * {@inheritDoc}
-         */
         override fun executeRequest(
             request: UpdateObservabilityObjectRequest,
             user: User?,

--- a/src/main/kotlin/org/opensearch/observability/action/UpdateObservabilityObjectRequest.kt
+++ b/src/main/kotlin/org/opensearch/observability/action/UpdateObservabilityObjectRequest.kt
@@ -91,9 +91,6 @@ internal class UpdateObservabilityObjectRequest :
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun toXContent(
         builder: XContentBuilder?,
         params: ToXContent.Params?,
@@ -117,9 +114,6 @@ internal class UpdateObservabilityObjectRequest :
         this.objectId = objectId
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Throws(IOException::class)
     constructor(input: StreamInput) : super(input) {
         objectId = input.readString()
@@ -134,9 +128,6 @@ internal class UpdateObservabilityObjectRequest :
             )
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Throws(IOException::class)
     override fun writeTo(output: StreamOutput) {
         super.writeTo(output)
@@ -146,9 +137,6 @@ internal class UpdateObservabilityObjectRequest :
         output.writeOptionalWriteable(objectData)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun validate(): ActionRequestValidationException? {
         var validationException: ActionRequestValidationException? = null
         if (Strings.isNullOrEmpty(objectId)) {

--- a/src/main/kotlin/org/opensearch/observability/action/UpdateObservabilityObjectResponse.kt
+++ b/src/main/kotlin/org/opensearch/observability/action/UpdateObservabilityObjectResponse.kt
@@ -65,17 +65,11 @@ internal class UpdateObservabilityObjectResponse(
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Throws(IOException::class)
     override fun writeTo(output: StreamOutput) {
         output.writeString(objectId)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun toXContent(
         builder: XContentBuilder?,
         params: ToXContent.Params?,

--- a/src/main/kotlin/org/opensearch/observability/metrics/BasicCounter.kt
+++ b/src/main/kotlin/org/opensearch/observability/metrics/BasicCounter.kt
@@ -13,23 +13,14 @@ import java.util.concurrent.atomic.LongAdder
 class BasicCounter : Counter<Long> {
     private val count = LongAdder()
 
-    /**
-     * {@inheritDoc}
-     */
     override fun increment() {
         count.increment()
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun add(n: Long) {
         count.add(n)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override val value: Long
         get() = count.toLong()
 

--- a/src/main/kotlin/org/opensearch/observability/metrics/RollingCounter.kt
+++ b/src/main/kotlin/org/opensearch/observability/metrics/RollingCounter.kt
@@ -19,16 +19,10 @@ internal class RollingCounter(
     private val capacity: Long = window / interval * 2
     private val timeToCountMap = ConcurrentSkipListMap<Long, Long>()
 
-    /**
-     * {@inheritDoc}
-     */
     override fun increment() {
         add(1L)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun add(n: Long) {
         trim()
         timeToCountMap.compute(
@@ -36,14 +30,8 @@ internal class RollingCounter(
         ) { _: Long?, v: Long? -> if (v == null) n else v + n }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override val value get() = getValue(getPreKey(clock.millis()))
 
-    /**
-     * {@inheritDoc}
-     */
     fun getValue(key: Long): Long {
         return timeToCountMap[key] ?: return 0
     }

--- a/src/main/kotlin/org/opensearch/observability/model/Application.kt
+++ b/src/main/kotlin/org/opensearch/observability/model/Application.kt
@@ -151,9 +151,6 @@ internal data class Application(
         availabilityVisId = input.readString(),
     )
 
-    /**
-     * {@inheritDoc}
-     */
     override fun writeTo(output: StreamOutput) {
         output.writeString(name)
         output.writeString(description)
@@ -164,9 +161,6 @@ internal data class Application(
         output.writeString(availabilityVisId)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun toXContent(
         builder: XContentBuilder?,
         params: ToXContent.Params?,

--- a/src/main/kotlin/org/opensearch/observability/model/BaseResponse.kt
+++ b/src/main/kotlin/org/opensearch/observability/model/BaseResponse.kt
@@ -25,15 +25,9 @@ internal abstract class BaseResponse :
      */
     constructor()
 
-    /**
-     * {@inheritDoc}
-     */
     @Throws(IOException::class)
     constructor(input: StreamInput) : super(input)
 
-    /**
-     * {@inheritDoc}
-     */
     fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder = toXContent(XContentFactory.jsonBuilder(), params)
 
     /**

--- a/src/main/kotlin/org/opensearch/observability/model/Notebook.kt
+++ b/src/main/kotlin/org/opensearch/observability/model/Notebook.kt
@@ -152,9 +152,6 @@ internal data class Notebook(
         paragraphs = input.readList(Paragraph.reader),
     )
 
-    /**
-     * {@inheritDoc}
-     */
     override fun writeTo(output: StreamOutput) {
         output.writeString(name)
         output.writeString(dateCreated)
@@ -163,9 +160,6 @@ internal data class Notebook(
         output.writeCollection(paragraphs)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun toXContent(
         builder: XContentBuilder?,
         params: ToXContent.Params?,
@@ -298,9 +292,6 @@ internal data class Notebook(
             streamOutput.writeString(id)
         }
 
-        /**
-         * {@inheritDoc}
-         */
         override fun toXContent(
             builder: XContentBuilder?,
             params: ToXContent.Params?,
@@ -399,9 +390,6 @@ internal data class Notebook(
             output.writeString(executionTime)
         }
 
-        /**
-         * {@inheritDoc}
-         */
         override fun toXContent(
             builder: XContentBuilder?,
             params: ToXContent.Params?,
@@ -476,9 +464,6 @@ internal data class Notebook(
             output.writeString(inputType)
         }
 
-        /**
-         * {@inheritDoc}
-         */
         override fun toXContent(
             builder: XContentBuilder?,
             params: ToXContent.Params?,

--- a/src/main/kotlin/org/opensearch/observability/model/ObservabilityObjectDoc.kt
+++ b/src/main/kotlin/org/opensearch/observability/model/ObservabilityObjectDoc.kt
@@ -138,9 +138,6 @@ data class ObservabilityObjectDoc(
         objectData = input.readOptionalWriteable(getReaderForObjectType(input.readEnum(ObservabilityObjectType::class.java))),
     )
 
-    /**
-     * {@inheritDoc}
-     */
     override fun writeTo(output: StreamOutput) {
         output.writeString(objectId)
         output.writeInstant(updatedTime)
@@ -152,9 +149,6 @@ data class ObservabilityObjectDoc(
         output.writeOptionalWriteable(objectData)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun toXContent(
         builder: XContentBuilder?,
         params: ToXContent.Params?,

--- a/src/main/kotlin/org/opensearch/observability/model/ObservabilityObjectSearchResult.kt
+++ b/src/main/kotlin/org/opensearch/observability/model/ObservabilityObjectSearchResult.kt
@@ -61,9 +61,6 @@ internal class ObservabilityObjectSearchResult : SearchResults<ObservabilityObje
         OBJECT_LIST_FIELD,
     )
 
-    /**
-     * {@inheritDoc}
-     */
     override fun parseItem(
         parser: XContentParser,
         useId: String?,

--- a/src/main/kotlin/org/opensearch/observability/model/OperationalPanel.kt
+++ b/src/main/kotlin/org/opensearch/observability/model/OperationalPanel.kt
@@ -160,9 +160,6 @@ internal data class OperationalPanel(
         applicationId = input.readOptionalString(),
     )
 
-    /**
-     * {@inheritDoc}
-     */
     override fun writeTo(output: StreamOutput) {
         output.writeString(name)
         output.writeCollection(visualizations)
@@ -171,9 +168,6 @@ internal data class OperationalPanel(
         output.writeOptionalString(applicationId)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun toXContent(
         builder: XContentBuilder?,
         params: ToXContent.Params?,
@@ -304,9 +298,6 @@ internal data class OperationalPanel(
             streamOutput.writeInt(h)
         }
 
-        /**
-         * {@inheritDoc}
-         */
         override fun toXContent(
             builder: XContentBuilder?,
             params: ToXContent.Params?,
@@ -392,9 +383,6 @@ internal data class OperationalPanel(
             output.writeString(from)
         }
 
-        /**
-         * {@inheritDoc}
-         */
         override fun toXContent(
             builder: XContentBuilder?,
             params: ToXContent.Params?,
@@ -468,9 +456,6 @@ internal data class OperationalPanel(
             output.writeString(language)
         }
 
-        /**
-         * {@inheritDoc}
-         */
         override fun toXContent(
             builder: XContentBuilder?,
             params: ToXContent.Params?,

--- a/src/main/kotlin/org/opensearch/observability/model/SavedQuery.kt
+++ b/src/main/kotlin/org/opensearch/observability/model/SavedQuery.kt
@@ -143,9 +143,6 @@ internal data class SavedQuery(
         selectedFields = input.readOptionalWriteable(SelectedFields.reader),
     )
 
-    /**
-     * {@inheritDoc}
-     */
     override fun writeTo(output: StreamOutput) {
         output.writeString(name)
         output.writeString(description)
@@ -155,9 +152,6 @@ internal data class SavedQuery(
         output.writeOptionalWriteable(selectedFields)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun toXContent(
         builder: XContentBuilder?,
         params: ToXContent.Params?,
@@ -235,18 +229,12 @@ internal data class SavedQuery(
             text = input.readString(),
         )
 
-        /**
-         * {@inheritDoc}
-         */
         override fun writeTo(output: StreamOutput) {
             output.writeString(start)
             output.writeString(end)
             output.writeString(text)
         }
 
-        /**
-         * {@inheritDoc}
-         */
         override fun toXContent(
             builder: XContentBuilder?,
             params: ToXContent.Params?,
@@ -317,17 +305,11 @@ internal data class SavedQuery(
             type = input.readString(),
         )
 
-        /**
-         * {@inheritDoc}
-         */
         override fun writeTo(output: StreamOutput) {
             output.writeString(name)
             output.writeString(type)
         }
 
-        /**
-         * {@inheritDoc}
-         */
         override fun toXContent(
             builder: XContentBuilder?,
             params: ToXContent.Params?,
@@ -411,17 +393,11 @@ internal data class SavedQuery(
             tokens = input.readList(Token.reader),
         )
 
-        /**
-         * {@inheritDoc}
-         */
         override fun writeTo(output: StreamOutput) {
             output.writeString(text)
             output.writeCollection(tokens)
         }
 
-        /**
-         * {@inheritDoc}
-         */
         override fun toXContent(
             builder: XContentBuilder?,
             params: ToXContent.Params?,

--- a/src/main/kotlin/org/opensearch/observability/model/SavedVisualization.kt
+++ b/src/main/kotlin/org/opensearch/observability/model/SavedVisualization.kt
@@ -225,9 +225,6 @@ internal data class SavedVisualization(
         selectedLabels = input.readOptionalWriteable(SelectedLabels.reader),
     )
 
-    /**
-     * {@inheritDoc}
-     */
     override fun writeTo(output: StreamOutput) {
         output.writeString(name)
         output.writeString(description)
@@ -244,9 +241,6 @@ internal data class SavedVisualization(
         output.writeOptionalWriteable(selectedLabels)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun toXContent(
         builder: XContentBuilder?,
         params: ToXContent.Params?,
@@ -319,16 +313,10 @@ internal data class SavedVisualization(
             label = input.readString(),
         )
 
-        /**
-         * {@inheritDoc}
-         */
         override fun writeTo(output: StreamOutput) {
             output.writeString(label)
         }
 
-        /**
-         * {@inheritDoc}
-         */
         override fun toXContent(
             builder: XContentBuilder?,
             params: ToXContent.Params?,
@@ -405,16 +393,10 @@ internal data class SavedVisualization(
             labels = input.readList(Token.reader),
         )
 
-        /**
-         * {@inheritDoc}
-         */
         override fun writeTo(output: StreamOutput) {
             output.writeCollection(labels)
         }
 
-        /**
-         * {@inheritDoc}
-         */
         override fun toXContent(
             builder: XContentBuilder?,
             params: ToXContent.Params?,

--- a/src/main/kotlin/org/opensearch/observability/model/SearchResults.kt
+++ b/src/main/kotlin/org/opensearch/observability/model/SearchResults.kt
@@ -187,9 +187,6 @@ internal abstract class SearchResults<ItemClass : BaseModel> : BaseModel {
         objectList = input.readList(reader),
     )
 
-    /**
-     * {@inheritDoc}
-     */
     override fun writeTo(output: StreamOutput) {
         output.writeLong(startIndex)
         output.writeLong(totalHits)
@@ -198,9 +195,6 @@ internal abstract class SearchResults<ItemClass : BaseModel> : BaseModel {
         output.writeList(objectList)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun toXContent(
         builder: XContentBuilder?,
         params: Params?,

--- a/src/main/kotlin/org/opensearch/observability/model/Timestamp.kt
+++ b/src/main/kotlin/org/opensearch/observability/model/Timestamp.kt
@@ -112,9 +112,6 @@ internal data class Timestamp(
         dslType = input.readString(),
     )
 
-    /**
-     * {@inheritDoc}
-     */
     override fun writeTo(output: StreamOutput) {
         output.writeString(name)
         output.writeString(index)
@@ -122,9 +119,6 @@ internal data class Timestamp(
         output.writeString(dslType)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun toXContent(
         builder: XContentBuilder?,
         params: ToXContent.Params?,

--- a/src/main/kotlin/org/opensearch/observability/resthandler/ObservabilityRestHandler.kt
+++ b/src/main/kotlin/org/opensearch/observability/resthandler/ObservabilityRestHandler.kt
@@ -52,14 +52,8 @@ internal class ObservabilityRestHandler : BaseRestHandler() {
         private val log by logger(ObservabilityRestHandler::class.java)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun getName(): String = OBSERVABILITY_ACTION
 
-    /**
-     * {@inheritDoc}
-     */
     override fun routes(): List<Route> =
         listOf(
             /*
@@ -94,9 +88,6 @@ internal class ObservabilityRestHandler : BaseRestHandler() {
             Route(DELETE, OBSERVABILITY_URL),
         )
 
-    /**
-     * {@inheritDoc}
-     */
     override fun responseParams(): Set<String> =
         setOf(
             OBJECT_ID_FIELD,
@@ -205,9 +196,6 @@ internal class ObservabilityRestHandler : BaseRestHandler() {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun prepareRequest(
         request: RestRequest,
         client: NodeClient,

--- a/src/main/kotlin/org/opensearch/observability/resthandler/ObservabilityStatsRestHandler.kt
+++ b/src/main/kotlin/org/opensearch/observability/resthandler/ObservabilityStatsRestHandler.kt
@@ -20,27 +20,15 @@ internal class ObservabilityStatsRestHandler : BaseRestHandler() {
         private const val OBSERVABILITY_STATS_URL = "$BASE_OBSERVABILITY_URI/_local/stats"
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun getName(): String = OBSERVABILITY_STATS_ACTION
 
-    /**
-     * {@inheritDoc}
-     */
     override fun routes(): List<Route> =
         listOf(
             Route(GET, OBSERVABILITY_STATS_URL),
         )
 
-    /**
-     * {@inheritDoc}
-     */
     override fun responseParams(): Set<String> = setOf()
 
-    /**
-     * {@inheritDoc}
-     */
     override fun prepareRequest(
         request: RestRequest,
         client: NodeClient,

--- a/src/main/kotlin/org/opensearch/observability/resthandler/RestResponseToXContentListener.kt
+++ b/src/main/kotlin/org/opensearch/observability/resthandler/RestResponseToXContentListener.kt
@@ -22,9 +22,6 @@ import org.opensearch.rest.action.RestToXContentListener
 internal class RestResponseToXContentListener<Response : BaseResponse>(
     channel: RestChannel,
 ) : RestToXContentListener<Response>(channel) {
-    /**
-     * {@inheritDoc}
-     */
     override fun buildResponse(
         response: Response,
         builder: XContentBuilder?,
@@ -43,8 +40,5 @@ internal class RestResponseToXContentListener<Response : BaseResponse>(
         return BytesRestResponse(getStatus(response), builder)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun getStatus(response: Response): RestStatus = response.getStatus()
 }

--- a/src/main/kotlin/org/opensearch/observability/util/SecureIndexClient.kt
+++ b/src/main/kotlin/org/opensearch/observability/util/SecureIndexClient.kt
@@ -47,9 +47,6 @@ import org.opensearch.transport.client.Client
 internal class SecureIndexClient(
     private val client: Client,
 ) : Client by client {
-    /**
-     * {@inheritDoc}
-     */
     override fun <Request : ActionRequest, Response : ActionResponse> execute(
         action: ActionType<Response>,
         request: Request,
@@ -61,9 +58,6 @@ internal class SecureIndexClient(
             .use { return client.execute(action, request) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun <Request : ActionRequest, Response : ActionResponse> execute(
         action: ActionType<Response>,
         request: Request,
@@ -76,9 +70,6 @@ internal class SecureIndexClient(
             .use { return client.execute(action, request, listener) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun index(request: IndexRequest): ActionFuture<IndexResponse> {
         client
             .threadPool()
@@ -87,9 +78,6 @@ internal class SecureIndexClient(
             .use { return client.index(request) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun index(
         request: IndexRequest,
         listener: ActionListener<IndexResponse>,
@@ -101,9 +89,6 @@ internal class SecureIndexClient(
             .use { return client.index(request, listener) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun update(request: UpdateRequest): ActionFuture<UpdateResponse> {
         client
             .threadPool()
@@ -112,9 +97,6 @@ internal class SecureIndexClient(
             .use { return client.update(request) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun update(
         request: UpdateRequest,
         listener: ActionListener<UpdateResponse>,
@@ -126,9 +108,6 @@ internal class SecureIndexClient(
             .use { return client.update(request, listener) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun delete(request: DeleteRequest): ActionFuture<DeleteResponse> {
         client
             .threadPool()
@@ -137,9 +116,6 @@ internal class SecureIndexClient(
             .use { return client.delete(request) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun delete(
         request: DeleteRequest,
         listener: ActionListener<DeleteResponse>,
@@ -151,9 +127,6 @@ internal class SecureIndexClient(
             .use { return client.delete(request, listener) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun bulk(request: BulkRequest): ActionFuture<BulkResponse> {
         client
             .threadPool()
@@ -162,9 +135,6 @@ internal class SecureIndexClient(
             .use { return client.bulk(request) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun bulk(
         request: BulkRequest,
         listener: ActionListener<BulkResponse>,
@@ -176,9 +146,6 @@ internal class SecureIndexClient(
             .use { return client.bulk(request, listener) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun get(request: GetRequest): ActionFuture<GetResponse> {
         client
             .threadPool()
@@ -187,9 +154,6 @@ internal class SecureIndexClient(
             .use { return client.get(request) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun get(
         request: GetRequest,
         listener: ActionListener<GetResponse>,
@@ -201,9 +165,6 @@ internal class SecureIndexClient(
             .use { return client.get(request, listener) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun multiGet(request: MultiGetRequest): ActionFuture<MultiGetResponse> {
         client
             .threadPool()
@@ -212,9 +173,6 @@ internal class SecureIndexClient(
             .use { return client.multiGet(request) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun multiGet(
         request: MultiGetRequest,
         listener: ActionListener<MultiGetResponse>,
@@ -226,9 +184,6 @@ internal class SecureIndexClient(
             .use { return client.multiGet(request, listener) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun search(request: SearchRequest): ActionFuture<SearchResponse> {
         client
             .threadPool()
@@ -237,9 +192,6 @@ internal class SecureIndexClient(
             .use { return client.search(request) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun search(
         request: SearchRequest,
         listener: ActionListener<SearchResponse>,
@@ -251,9 +203,6 @@ internal class SecureIndexClient(
             .use { return client.search(request, listener) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun searchScroll(request: SearchScrollRequest): ActionFuture<SearchResponse> {
         client
             .threadPool()
@@ -262,9 +211,6 @@ internal class SecureIndexClient(
             .use { return client.searchScroll(request) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun searchScroll(
         request: SearchScrollRequest,
         listener: ActionListener<SearchResponse>,
@@ -276,9 +222,6 @@ internal class SecureIndexClient(
             .use { return client.searchScroll(request, listener) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun multiSearch(request: MultiSearchRequest): ActionFuture<MultiSearchResponse> {
         client
             .threadPool()
@@ -287,9 +230,6 @@ internal class SecureIndexClient(
             .use { return client.multiSearch(request) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun multiSearch(
         request: MultiSearchRequest,
         listener: ActionListener<MultiSearchResponse>,
@@ -301,9 +241,6 @@ internal class SecureIndexClient(
             .use { return client.multiSearch(request, listener) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun termVectors(request: TermVectorsRequest): ActionFuture<TermVectorsResponse> {
         client
             .threadPool()
@@ -312,9 +249,6 @@ internal class SecureIndexClient(
             .use { return client.termVectors(request) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun termVectors(
         request: TermVectorsRequest,
         listener: ActionListener<TermVectorsResponse>,
@@ -326,9 +260,6 @@ internal class SecureIndexClient(
             .use { return client.termVectors(request, listener) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun multiTermVectors(request: MultiTermVectorsRequest): ActionFuture<MultiTermVectorsResponse> {
         client
             .threadPool()
@@ -337,9 +268,6 @@ internal class SecureIndexClient(
             .use { return client.multiTermVectors(request) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun multiTermVectors(
         request: MultiTermVectorsRequest,
         listener: ActionListener<MultiTermVectorsResponse>,
@@ -351,9 +279,6 @@ internal class SecureIndexClient(
             .use { return client.multiTermVectors(request, listener) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun explain(request: ExplainRequest): ActionFuture<ExplainResponse> {
         client
             .threadPool()
@@ -362,9 +287,6 @@ internal class SecureIndexClient(
             .use { return client.explain(request) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun explain(
         request: ExplainRequest,
         listener: ActionListener<ExplainResponse>,
@@ -376,9 +298,6 @@ internal class SecureIndexClient(
             .use { return client.explain(request, listener) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun clearScroll(request: ClearScrollRequest): ActionFuture<ClearScrollResponse> {
         client
             .threadPool()
@@ -387,9 +306,6 @@ internal class SecureIndexClient(
             .use { return client.clearScroll(request) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun clearScroll(
         request: ClearScrollRequest,
         listener: ActionListener<ClearScrollResponse>,
@@ -401,9 +317,6 @@ internal class SecureIndexClient(
             .use { return client.clearScroll(request, listener) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun fieldCaps(request: FieldCapabilitiesRequest): ActionFuture<FieldCapabilitiesResponse> {
         client
             .threadPool()
@@ -412,9 +325,6 @@ internal class SecureIndexClient(
             .use { return client.fieldCaps(request) }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     override fun fieldCaps(
         request: FieldCapabilitiesRequest,
         listener: ActionListener<FieldCapabilitiesResponse>,


### PR DESCRIPTION
### Description
Removes all 119 `{@inheritDoc}`-only KDoc blocks across 30 Kotlin files. KDoc automatically inherits documentation for overrides and does not recognize this JavaDoc annotation, so leaving the blocks in place produces broken generated documentation. No runtime logic is changed.

### Related Issues
Resolves #1491

### Validation
- `./gradlew --no-daemon ktlint detekt compileKotlin`
- `./gradlew --no-daemon test`
- full source search confirms zero remaining `{@inheritDoc}` annotations
- deletion audit confirms the diff contains only the 119 three-line KDoc blocks
- `git diff --check`

### Check List
- [x] New functionality includes testing. (Not applicable; documentation-only cleanup, existing test suite passes.)
- [x] New functionality has been documented. (Not applicable; this fixes generated documentation.)
- [x] API changes companion pull request created. (Not applicable; no API changes.)
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR created. (Not applicable; this change affects generated KDoc only.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.